### PR TITLE
Implement full Syndication Configuration API

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -1,22 +1,125 @@
-# Python Package Management with uv
+# CLAUDE.MD
 
-Use uv exclusively for Python package management in this project.
+Repository guidance for AI coding agents and contributors working on `brightcove_async`.
 
-## Package Management Commands
+## Project Summary
 
-- All Python dependencies **must be installed, synchronized, and locked** using uv
-- Never use pip, pip-tools, poetry, or conda directly for dependency management
+- Package: `brightcove_async`
+- Purpose: async Python client for Brightcove APIs (CMS, Analytics, Audience, Syndication, Dynamic Ingest, Ingest Profiles)
+- Python: `>=3.13`
+- Package manager: `uv` only
+- Core stack: `aiohttp`, `pydantic`, `pydantic-settings`, `aiolimiter`, `tenacity`
 
-Use these commands:
+## Mandatory Tooling Rules
 
-- Add a runtime dependency: `uv add <package>`
-- Add a dev dependency: `uv add --group dev <package>`
-- Remove a dependency: `uv remove <package>`
-- Sync environment from the lockfile: `uv sync`
-- Lock dependencies: `uv lock`
+- Use `uv` exclusively for dependency management and command execution.
+- Never use `pip`, `poetry`, or `conda` directly in this repo.
 
-## Running Python Code
+Common commands:
 
-- Run a Python script with `uv run python <script-name>.py` (or `uv run python -m <module>`)
-- Run Python tools with `uv run <tool>` (e.g. `uv run pytest`, `uv run ruff`, `uv run ty`, `uv run pre-commit`)
-- Launch a Python REPL with `uv run python`
+- Install/sync env: `uv sync`
+- Add runtime dependency: `uv add <package>`
+- Add dev dependency: `uv add --group dev <package>`
+- Remove dependency: `uv remove <package>`
+- Re-lock dependencies: `uv lock`
+
+Run tools with `uv run`:
+
+- Tests: `uv run pytest`
+- Lint: `uv run ruff check --fix`
+- Format: `uv run ruff format`
+- Type check: `uv run ty check`
+- Pre-commit (all files): `uv run pre-commit run --all-files`
+
+## Local Development
+
+1. Sync environment:
+	 - `uv sync`
+2. Set OAuth credentials for local integration use:
+	 - `export CLIENT_ID="..."`
+	 - `export CLIENT_SECRET="..."`
+3. Run tests and quality checks before finishing changes:
+	 - `uv run pytest`
+	 - `uv run ruff check --fix`
+	 - `uv run ruff format`
+	 - `uv run ty check`
+
+## Repository Layout
+
+- `src/brightcove_async/client.py`: main async client/context manager, lazy service initialization.
+- `src/brightcove_async/initialise.py`: factory `initialise_brightcove_client`.
+- `src/brightcove_async/settings.py`: env-backed settings and API base URL config.
+- `src/brightcove_async/oauth/oauth.py`: OAuth token retrieval and caching.
+- `src/brightcove_async/services/`: API service wrappers.
+- `src/brightcove_async/schemas/`: Pydantic models and request/query schemas.
+- `src/brightcove_async/registry.py`: service registration and per-service rate limits.
+- `tests/`: pytest suite for client, services, schemas, oauth, registry.
+- `brightcove_open_api_specs/` and `openapi.yaml`: API spec inputs/reference files.
+
+## Architecture Notes
+
+### Client lifecycle
+
+- Construct with `initialise_brightcove_client()`.
+- Always use the client as an async context manager:
+	- `async with client as c: ...`
+- Internally, session and OAuth client are lazy-initialized.
+- Services are lazy-loaded and cached by name on first access (`c.cms`, `c.analytics`, etc.).
+
+### Request pipeline
+
+- Service methods call `Base.fetch_data(...)`.
+- `Base.fetch_data` responsibilities:
+	- obtains OAuth headers (unless custom headers provided)
+	- applies per-service rate limiting via `AsyncLimiter`
+	- performs request with `aiohttp`
+	- maps HTTP errors to custom Brightcove exceptions
+	- retries transient failures via `tenacity`
+	- validates/parses response with Pydantic models
+
+### Service registry and limits
+
+- `build_service_registry()` in `registry.py` defines service class, base URL, and request rate.
+- If adding a new service, update:
+	- `registry.py`
+	- `client.py` service property
+	- tests for registry/client behavior
+
+## Change Patterns
+
+### Adding a new endpoint to an existing service
+
+1. Add or update schema models in `src/brightcove_async/schemas/`.
+2. Add query/body params model in `schemas/params.py` when needed.
+3. Add async method to the relevant service in `src/brightcove_async/services/`.
+4. Use `fetch_data` with an explicit Pydantic model for all JSON endpoints — `fetch_data` is strictly for JSON request/response pairs where the response is validated against the model.
+5. For non-JSON endpoints (e.g. DELETE with no response body, or `text/plain` responses), do **not** use `fetch_data`. Instead, call `self._session.request(...)` directly using `self.limiter` and `await self._oauth.headers`, and handle HTTP errors via a `_raise_for_status` helper that maps `aiohttp.ClientResponseError` to Brightcove exceptions. See `Syndication` service for the established pattern.
+6. Add/extend tests in `tests/test_<service>_service.py`.
+
+### Adding a new service
+
+1. Create service class in `src/brightcove_async/services/` inheriting `Base`.
+2. Register it in `src/brightcove_async/registry.py` with suitable RPS limit.
+3. Expose it as a property on `BrightcoveClient` in `src/brightcove_async/client.py`.
+4. Add unit tests for lazy initialization and service methods.
+
+## Testing Expectations
+
+- Use `pytest` with `pytest-asyncio` for async methods.
+- Prefer mocking `fetch_data` in service tests unless explicitly testing shared request behavior.
+- For request/exception behavior, add tests in `test_base_service.py`.
+- Keep tests deterministic and offline by default.
+
+## Style and Quality
+
+- Keep code fully typed and async-first.
+- Reuse existing patterns for service methods and model validation.
+- Avoid introducing blocking I/O in async paths.
+- Keep public API changes intentional and reflected in tests.
+
+## Notes for Agents
+
+- Before editing, inspect related service + tests to preserve project patterns.
+- Prefer minimal, focused changes over broad refactors.
+- If changing behavior, update or add tests in the same PR.
+- Run quality checks with `uv run` commands before concluding work.

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -93,7 +93,7 @@ Run tools with `uv run`:
 2. Add query/body params model in `schemas/params.py` when needed.
 3. Add async method to the relevant service in `src/brightcove_async/services/`.
 4. Use `fetch_data` with an explicit Pydantic model for all JSON endpoints — `fetch_data` is strictly for JSON request/response pairs where the response is validated against the model.
-5. For non-JSON endpoints (e.g. DELETE with no response body, or `text/plain` responses), do **not** use `fetch_data`. Instead, call `self._session.request(...)` directly using `self.limiter` and `await self._oauth.headers`, and handle HTTP errors via a `_raise_for_status` helper that maps `aiohttp.ClientResponseError` to Brightcove exceptions. See `Syndication` service for the established pattern.
+5. For non-JSON endpoints (e.g. DELETE with no response body, or `text/plain` responses), do **not** use `fetch_data`. Instead, use the Base helpers (`self._delete`, `self._get_text`, `self._put_text`), which handle rate limiting, retries, and `_raise_for_status` error mapping for you.
 6. Add/extend tests in `tests/test_<service>_service.py`.
 
 ### Adding a new service

--- a/brightcove_open_api_specs/configuration-openapi.yaml
+++ b/brightcove_open_api_specs/configuration-openapi.yaml
@@ -1,0 +1,472 @@
+openapi: '3.0.0'
+x-bc-implicit-head: true
+x-bc-implicit-options: true
+x-bc-upstream: 'https://mrss_config_server'
+info:
+  description: |-
+    The Syndication Configuration API allows you to create, manage, and retrieve MRSS feeds generated from your Video Cloud video library.
+
+    **Base URL: 'https://social.api.brightcove.com/v1'**
+  version: 1.0.0
+  title: Brightcove Syndication Configuration API
+  x-bc-access: public
+servers:
+  - url: 'https://social.api.brightcove.com/v1'
+    variables: {}
+paths:
+  '/accounts/{{account_id}}/mrss/syndications':
+    post:
+      tags:
+        - Syndications
+      summary: Create a new syndication
+      description: >-
+        Creates a new syndication.
+      operationId: postSyndication
+      security:
+        - BC_OAuth2:
+          - video-cloud/social/mrss/write
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Syndication'
+      responses:
+        '201':
+          description: The newly created syndication.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Syndication'
+        '400':
+          description: Request body syntax error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '401':
+          description: Insufficient permissions to access this API method
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '422':
+          description: Invalid request body fields or values
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+    get:
+      tags:
+        - Syndications
+      summary: Get all syndications
+      description: >-
+        Gets a list of all syndications currently configured for the account.
+      operationId: getSyndications
+      security:
+        - BC_OAuth2:
+          - video-cloud/social/mrss/read
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+      responses:
+        '200':
+          description: A list of syndications.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SyndicationList'
+        '401':
+          description: Insufficient permissions to access this API method
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+  '/accounts/{{account_id}}/mrss/syndications/{syndication_id}':
+    put:
+      tags:
+        - Syndications
+      summary: Update a syndication
+      description: >-
+        Updates the configuration data for a syndication.  A fully populated Syndication object should be passed as the request body.  Read-only fields can be omitted, and will be ignored if they are included.  Note that the *type* property cannot be changed from the value specified when the syndication was created.
+      operationId: putSyndication
+      security:
+        - BC_OAuth2:
+          - video-cloud/social/mrss/write
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+        - $ref: '#/components/parameters/SyndicationId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Syndication'
+      responses:
+        '200':
+          description: The updated syndication.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Syndication'
+        '401':
+          description: Insufficient permissions to access this API method
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '404':
+          description: Syndication not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+    patch:
+      tags:
+        - Syndications
+      summary: Update a syndication
+      description: >-
+        Updates the configuration data for a syndication.  A Syndication object specifying non-null values for writable fields to be updated should be passed as the request body.  Note that the *type* property cannot be changed from the value specified when the syndication was created.
+      operationId: patchSyndication
+      security:
+        - BC_OAuth2:
+          - video-cloud/social/mrss/write
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+        - $ref: '#/components/parameters/SyndicationId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Syndication'
+      responses:
+        '200':
+          description: The updated syndication.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Syndication'
+        '401':
+          description: Insufficient permissions to access this API method
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '404':
+          description: Syndication not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+    delete:
+      tags:
+        - Syndications
+      summary: Delete a syndication
+      description: >-
+        Deletes a syndication.
+      operationId: deleteSyndication
+      security:
+        - BC_OAuth2:
+          - video-cloud/social/mrss/write
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+        - $ref: '#/components/parameters/SyndicationId'
+      responses:
+        '200':
+          description: Syndication successfully deleted
+        '401':
+          description: Insufficient permissions to access this API method
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '404':
+          description: Syndication not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+    get:
+      tags:
+        - Syndications
+      summary: Get a syndication
+      description: >-
+        Gets the configuration data for a syndication.
+      operationId: getSyndication
+      security:
+        - BC_OAuth2:
+          - video-cloud/social/mrss/read
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+        - $ref: '#/components/parameters/SyndicationId'
+      responses:
+        '200':
+          description: The specified syndication.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Syndication'
+        '401':
+          description: Insufficient permissions to access this API method
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '404':
+          description: Syndication not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+  '/accounts/{{account_id}}/mrss/syndications/{syndication_id}/template':
+    put:
+      tags:
+        - Templates
+      summary: Upload a custom feed template
+      description: >-
+        Uploads a custom feed template to a universal syndication.
+      operationId: putTemplate
+      security:
+        - BC_OAuth2:
+          - video-cloud/social/mrss/write
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+        - $ref: '#/components/parameters/SyndicationId'
+      requestBody:
+        description: A feed template document
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: The newly uploaded template.
+        '400':
+          description: Request body syntax error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '401':
+          description: Insufficient permissions to access this API method
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+    get:
+      tags:
+        - Templates
+      summary: Get a custom feed template
+      description: >-
+        Gets a universal syndication's custom feed template.
+      operationId: getTemplate
+      security:
+        - BC_OAuth2:
+          - video-cloud/social/mrss/read
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+        - $ref: '#/components/parameters/SyndicationId'
+      responses:
+        '200':
+          description: The universal syndication's feed template.  If one has not yet been uploaded, a default empty template will be returned.
+        '401':
+          description: Insufficient permissions to access this API method
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '403':
+          description: Forbidden, syndication was not of type universal
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '404':
+          description: Syndication not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+        '500':
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrorList'
+components:
+  schemas:
+    Syndication:
+      type: object
+      required:
+      - name
+      - type
+      properties:
+        id:
+          type: string
+          description: Id of this syndication
+          readOnly: true
+        name:
+          type: string
+          description: Name of this syndication
+        type:
+          type: string
+          enum: [
+            "advanced",
+            "google",
+            "iphone",
+            "ipad",
+            "mp4",
+            "itunes",
+            "roku",
+            "source",
+            "universal"
+          ]
+          description: The syndication type.  Valid values are [advanced, google, iphone, ipad, mp4, itunes, roku, source, universal].  Cannot be changed after syndication creation time.
+        include_all_content:
+          type: boolean
+          description: If true, all content is included in this syndication.  If false, a valid include_filter property must be specified for the syndication.
+        include_filter:
+          type: string
+          description: A CMS video search filter string used to select the subset of content included in this syndication.  The include_all_content field must be set to false if a value is specified for this property.
+        sort:
+          type: string
+          description: A CMS video sorting specifier indicating the desired feed results return order.  CMS-supported values like "name", "reference_id", "created_at", "published_at", "updated_at", "schedule.starts_at", "schedule.ends_at", "state", "plays_total", and "plays_trailing_week" can be specified.  To sort in descending order, preface the value with a minus (-) sign, i.e. "-created_at".  If no value is specified, the feed will be sorted by most recent updated_at date by default.
+        title:
+          type: string
+          description: The title of this feed. Will be included inside of the <channel> tag for some syndication types.
+        description:
+          type: string
+          description: The description of this feed. Will be included inside of the <channel> tag for some syndication types.
+        syndication_url:
+          type: string
+          readOnly: true
+          description: The URL of this syndication's feed.  Read-only.
+        destination_url:
+          type: string
+          description: The URL to be included inside of the <channel> tag in the feed.
+        keywords:
+            type: string
+            description: A comma-separated list of keywords for iTunes
+        author:
+            type: string
+            description: iTunes author specification
+        category:
+            type: string
+            description: iTunes category specification
+        album_art_url:
+            type: string
+            description: iTunes album art url.
+        explicit:
+            type: string
+            enum: ["yes", "no"]
+            description: iTunes explicit content indicator, accepts "yes" or "no" values.
+        owner_name:
+            type: string
+            description: iTunes owner name.
+        owner_email:
+            type: string
+            description: iTunes owner email.
+        language:
+            type: string
+            description: iTunes or Roku feed language field.
+        fetch_sources:
+            type: boolean
+            description: For universal feeds, specifies whether the feed service should fetch video source metadata and make it available to the template.  The default value is true.  If source metadata is not needed by the template, setting this to false can improve feed generation performance.
+        fetch_digital_master:
+            type: boolean
+            description: For universal feeds, specifies whether the feed service should fetch digital master metadata and make it available to the template.  The default value is false.  If digital master metadata is not needed by the template, keeping this setting as false can improve feed generation performance.
+        fetch_dynamic_renditions:
+            type: boolean
+            description: For universal feeds, specifies whether the feed service should fetch dynamic rendition metadata and make it available to the template.  The default value is false.  If dynamic rendition metadata is not needed by the template, keeping this setting as false can improve feed generation performance.
+        content_type_header:
+            type: string
+            description: >-
+              If set, overrides the Content-Type header returned by the feed server for this syndication's feed. Otherwise the feed defaults to a syndication type-specific header value
+            example: 'application/xml'
+    SyndicationList:
+      type: array
+      items:
+        $ref: '#/components/schemas/Syndication'
+    ResponseError:
+      type: object
+      properties:
+        error_code:
+          type: string
+          description: Application error code
+          readOnly: true
+        message:
+          type: string
+          description: Application error message
+          readOnly: true
+    ResponseErrorList:
+      type: array
+      items:
+        $ref: '#/components/schemas/ResponseError'
+  parameters:
+    AccountId:
+      name: account_id
+      in: path
+      description: ID of the account
+      required: true
+      schema:
+        type: string
+    SyndicationId:
+      name: syndication_id
+      in: path
+      description: ID of the syndication
+      required: true
+      schema:
+        type: string
+  securitySchemes:
+    BC_OAuth2:
+      type: oauth2
+      description: >-
+        Brightcove OAuth API. See the [support documentation](/oauth/) or [Getting Access Tokens](/oauth/guides/getting-access-tokens.html) to learn more
+      flows:
+        clientCredentials:
+          tokenUrl: 'https://oauth.brightcove.com/v4/access_token'
+          scopes:
+            video-cloud/social/mrss/read: Read MRSS feed configuration data
+            video-cloud/social/mrss/write: Write MRSS feed configuration data

--- a/src/brightcove_async/exceptions.py
+++ b/src/brightcove_async/exceptions.py
@@ -77,6 +77,10 @@ class BrightcoveTooManyRequestsError(BrightcoveClientError):
     """Raised when too many requests are made to the Brightcove API."""
 
 
+class BrightcoveConnectionError(BrightcoveError):
+    """Raised when a connection to the Brightcove API cannot be established."""
+
+
 class BrightcoveServerError(BrightcoveError):
     """Base class for server errors."""
 

--- a/src/brightcove_async/services/base.py
+++ b/src/brightcove_async/services/base.py
@@ -15,6 +15,7 @@ from tenacity import (
 
 from brightcove_async.exceptions import (
     BrightcoveAuthError,
+    BrightcoveConnectionError,
     BrightcoveError,
     map_status_code_to_exception,
 )
@@ -22,6 +23,14 @@ from brightcove_async.protocols import OAuthClientProtocol
 
 T = TypeVar("T", bound=BaseModel)
 logger = logging.getLogger(__name__)
+
+brightcove_retry = retry(
+    retry=retry_if_exception_type(
+        (BrightcoveConnectionError, BrightcoveAuthError),
+    ),
+    wait=wait_exponential(multiplier=1, min=1, max=3),
+    stop=stop_after_attempt(5),
+)
 
 
 class Base(ABC):
@@ -67,13 +76,29 @@ class Base(ABC):
         """Property that must be defined in any subclass to indicate the base API URL."""
         return self._base_url
 
-    @retry(
-        retry=retry_if_exception_type(
-            (aiohttp.ClientConnectionError, BrightcoveAuthError),
-        ),
-        wait=wait_exponential(multiplier=1, min=1, max=3),
-        stop=stop_after_attempt(5),
-    )
+    async def _raise_for_status(
+        self, response: aiohttp.ClientResponse, endpoint: str
+    ) -> None:
+        try:
+            response.raise_for_status()
+        except aiohttp.ClientResponseError as e:
+            error_details: dict = {}
+            try:
+                error_body = await response.text()
+                error_details = {"response_body": error_body}
+            except Exception:
+                pass
+            exc_class: type[BrightcoveError] = map_status_code_to_exception(
+                HTTPStatus(e.status)
+            )
+            raise exc_class(
+                message=str(e.message),
+                status_code=e.status,
+                endpoint=endpoint,
+                details=error_details,
+            ) from e
+
+    @brightcove_retry
     async def fetch_data(
         self,
         endpoint: str,
@@ -88,6 +113,7 @@ class Base(ABC):
 
         body = (
             payload.model_dump(
+                mode="json",
                 exclude_none=True,
                 exclude_unset=True,
                 exclude_defaults=True,
@@ -96,35 +122,58 @@ class Base(ABC):
             else None
         )
 
-        async with (
-            self.limiter,
-            self._session.request(
-                method,
-                endpoint,
-                params=params,
-                headers=headers,
-                json=body,
-            ) as response,
-        ):
-            try:
-                response.raise_for_status()
-            except aiohttp.ClientResponseError as e:
-                error_details = {}
-                try:
-                    error_body = await response.text()
-                    error_details = {"response_body": error_body}
-                except Exception:
-                    pass
+        try:
+            async with (
+                self.limiter,
+                self._session.request(
+                    method,
+                    endpoint,
+                    params=params,
+                    headers=headers,
+                    json=body,
+                ) as response,
+            ):
+                await self._raise_for_status(response, endpoint)
+                json_data = await response.json()
+                return model.model_validate(json_data, strict=False)
+        except aiohttp.ClientConnectionError as e:
+            raise BrightcoveConnectionError(message=str(e), endpoint=endpoint) from e
 
-                exc_class: type[BrightcoveError] = map_status_code_to_exception(
-                    HTTPStatus(e.status),
-                )
-                raise exc_class(
-                    message=str(e.message),
-                    status_code=e.status,
-                    endpoint=endpoint,
-                    details=error_details,
-                ) from e
+    @brightcove_retry
+    async def _delete(self, endpoint: str) -> None:
+        try:
+            headers = await self._oauth.headers
+            async with (
+                self.limiter,
+                self._session.request("DELETE", endpoint, headers=headers) as response,
+            ):
+                await self._raise_for_status(response, endpoint)
+        except aiohttp.ClientConnectionError as e:
+            raise BrightcoveConnectionError(message=str(e), endpoint=endpoint) from e
 
-            json_data = await response.json()
-            return model.model_validate(json_data, strict=False)
+    @brightcove_retry
+    async def _get_text(self, endpoint: str) -> str:
+        try:
+            headers = await self._oauth.headers
+            async with (
+                self.limiter,
+                self._session.request("GET", endpoint, headers=headers) as response,
+            ):
+                await self._raise_for_status(response, endpoint)
+                return await response.text()
+        except aiohttp.ClientConnectionError as e:
+            raise BrightcoveConnectionError(message=str(e), endpoint=endpoint) from e
+
+    @brightcove_retry
+    async def _put_text(self, endpoint: str, content: str) -> None:
+        try:
+            headers = {**await self._oauth.headers, "Content-Type": "text/plain"}
+            async with (
+                self.limiter,
+                self._session.request(
+                    "PUT", endpoint, headers=headers, data=content
+                ) as response,
+            ):
+                await self._raise_for_status(response, endpoint)
+        except aiohttp.ClientConnectionError as e:
+            raise BrightcoveConnectionError(message=str(e), endpoint=endpoint) from e

--- a/src/brightcove_async/services/base.py
+++ b/src/brightcove_async/services/base.py
@@ -1,6 +1,5 @@
 import logging
 from abc import ABC
-from http import HTTPStatus
 from typing import TypeVar
 
 import aiohttp

--- a/src/brightcove_async/services/base.py
+++ b/src/brightcove_async/services/base.py
@@ -88,9 +88,7 @@ class Base(ABC):
                 error_details = {"response_body": error_body}
             except Exception:
                 pass
-            exc_class: type[BrightcoveError] = map_status_code_to_exception(
-                HTTPStatus(e.status)
-            )
+            exc_class: type[BrightcoveError] = map_status_code_to_exception(e.status)
             raise exc_class(
                 message=str(e.message),
                 status_code=e.status,

--- a/src/brightcove_async/services/syndication.py
+++ b/src/brightcove_async/services/syndication.py
@@ -4,17 +4,11 @@ from brightcove_async.protocols import OAuthClientProtocol
 from brightcove_async.schemas.syndication_model import (
     Syndication as SyndicationModel,
 )
-from brightcove_async.schemas.syndication_model import (
-    SyndicationList,
-)
+from brightcove_async.schemas.syndication_model import SyndicationList
 from brightcove_async.services.base import Base
 
 
 class Syndication(Base):
-    @property
-    def base_url(self) -> str:
-        return "https://edge.social.api.brightcove.com/v1/accounts/"
-
     def __init__(
         self,
         session: aiohttp.ClientSession,
@@ -26,7 +20,7 @@ class Syndication(Base):
 
     async def get_all_syndications(self, account_id: str) -> SyndicationList:
         return await self.fetch_data(
-            endpoint=f"{self.base_url}{account_id}/mrss/syndications",
+            endpoint=f"{self.base_url}/accounts/{account_id}/mrss/syndications",
             model=SyndicationList,
         )
 
@@ -36,6 +30,73 @@ class Syndication(Base):
         syndication_id: str,
     ) -> SyndicationModel:
         return await self.fetch_data(
-            endpoint=f"{self.base_url}{account_id}/mrss/syndications/{syndication_id}",
+            endpoint=f"{self.base_url}/accounts/{account_id}/mrss/syndications/{syndication_id}",
             model=SyndicationModel,
+        )
+
+    async def create_syndication(
+        self,
+        account_id: str,
+        syndication: SyndicationModel,
+    ) -> SyndicationModel:
+        return await self.fetch_data(
+            endpoint=f"{self.base_url}/accounts/{account_id}/mrss/syndications",
+            model=SyndicationModel,
+            method="POST",
+            payload=syndication,
+        )
+
+    async def update_syndication(
+        self,
+        account_id: str,
+        syndication_id: str,
+        syndication: SyndicationModel,
+    ) -> SyndicationModel:
+        return await self.fetch_data(
+            endpoint=f"{self.base_url}/accounts/{account_id}/mrss/syndications/{syndication_id}",
+            model=SyndicationModel,
+            method="PUT",
+            payload=syndication,
+        )
+
+    async def patch_syndication(
+        self,
+        account_id: str,
+        syndication_id: str,
+        syndication: SyndicationModel,
+    ) -> SyndicationModel:
+        return await self.fetch_data(
+            endpoint=f"{self.base_url}/accounts/{account_id}/mrss/syndications/{syndication_id}",
+            model=SyndicationModel,
+            method="PATCH",
+            payload=syndication,
+        )
+
+    async def delete_syndication(
+        self,
+        account_id: str,
+        syndication_id: str,
+    ) -> None:
+        await self._delete(
+            f"{self.base_url}/accounts/{account_id}/mrss/syndications/{syndication_id}"
+        )
+
+    async def get_template(
+        self,
+        account_id: str,
+        syndication_id: str,
+    ) -> str:
+        return await self._get_text(
+            f"{self.base_url}/accounts/{account_id}/mrss/syndications/{syndication_id}/template"
+        )
+
+    async def upload_template(
+        self,
+        account_id: str,
+        syndication_id: str,
+        content: str,
+    ) -> None:
+        await self._put_text(
+            f"{self.base_url}/accounts/{account_id}/mrss/syndications/{syndication_id}/template",
+            content,
         )

--- a/src/brightcove_async/settings.py
+++ b/src/brightcove_async/settings.py
@@ -13,7 +13,7 @@ class BrightcoveBaseAPIConfig(BaseSettings):
     """Base API configuration for Brightcove."""
 
     cms_base_url: str = "https://cms.api.brightcove.com/v1/accounts/"
-    syndication_base_url: str = "https://edge.social.api.brightcove.com/v1/accounts/"
+    syndication_base_url: str = "https://social.api.brightcove.com/v1"
     analytics_base_url: str = "https://analytics.api.brightcove.com/v1"
     dynamic_ingest_base_url: str = "https://ingest.api.brightcove.com/v1/accounts/"
     ingest_profiles_base_url: str = "https://ingestion.api.brightcove.com/v1/"

--- a/tests/test_base_service.py
+++ b/tests/test_base_service.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from brightcove_async.exceptions import (
     BrightcoveAuthError,
     BrightcoveBadValueError,
+    BrightcoveConnectionError,
     BrightcoveResourceNotFoundError,
 )
 from brightcove_async.services.base import Base
@@ -89,6 +90,70 @@ def test_limiter_singleton(base_service):
     limiter2 = base_service.limiter
 
     assert limiter1 is limiter2
+
+
+@pytest.mark.asyncio
+async def test_raise_for_status_passes_on_success(base_service):
+    """Test _raise_for_status does not raise when response is successful."""
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+
+    await base_service._raise_for_status(
+        mock_response, "https://api.example.com/v1/items"
+    )
+
+    mock_response.raise_for_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_raise_for_status_maps_404(base_service):
+    """Test _raise_for_status maps 404 to BrightcoveResourceNotFoundError."""
+    error = aiohttp.ClientResponseError(
+        request_info=AsyncMock(), history=(), status=404
+    )
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock(side_effect=error)
+    mock_response.text = AsyncMock(return_value="Not found")
+
+    with pytest.raises(BrightcoveResourceNotFoundError) as exc_info:
+        await base_service._raise_for_status(
+            mock_response, "https://api.example.com/v1/items/1"
+        )
+
+    assert exc_info.value.details == {"response_body": "Not found"}
+
+
+@pytest.mark.asyncio
+async def test_raise_for_status_maps_400(base_service):
+    """Test _raise_for_status maps 400 to BrightcoveBadValueError."""
+    error = aiohttp.ClientResponseError(
+        request_info=AsyncMock(), history=(), status=400
+    )
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock(side_effect=error)
+    mock_response.text = AsyncMock(return_value="Bad request")
+
+    with pytest.raises(BrightcoveBadValueError):
+        await base_service._raise_for_status(
+            mock_response, "https://api.example.com/v1/items"
+        )
+
+
+@pytest.mark.asyncio
+async def test_raise_for_status_includes_endpoint(base_service):
+    """Test _raise_for_status includes the endpoint in the raised exception."""
+    error = aiohttp.ClientResponseError(
+        request_info=AsyncMock(), history=(), status=404
+    )
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock(side_effect=error)
+    mock_response.text = AsyncMock(return_value="")
+
+    endpoint = "https://api.example.com/v1/items/42"
+    with pytest.raises(BrightcoveResourceNotFoundError) as exc_info:
+        await base_service._raise_for_status(mock_response, endpoint)
+
+    assert exc_info.value.endpoint == endpoint
 
 
 @pytest.mark.asyncio
@@ -272,6 +337,26 @@ async def test_fetch_data_handles_401_error(base_service, mock_session):
         )
 
     assert mock_session.request.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_translates_connection_error(base_service, mock_session):
+    """Test that aiohttp.ClientConnectionError is translated to BrightcoveConnectionError."""
+    mock_session.request.return_value.__aenter__.side_effect = (
+        aiohttp.ClientConnectionError("Connection failed")
+    )
+
+    from tenacity import RetryError
+
+    with pytest.raises(RetryError) as exc_info:
+        await base_service.fetch_data(
+            endpoint="https://api.example.com/v1/items",
+            model=DummyModel,
+        )
+
+    assert isinstance(
+        exc_info.value.last_attempt.exception(), BrightcoveConnectionError
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_syndication_service.py
+++ b/tests/test_syndication_service.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
@@ -12,10 +12,10 @@ from brightcove_async.schemas.syndication_model import (
 )
 from brightcove_async.services.syndication import Syndication
 
+BASE_URL = "https://social.api.brightcove.com/v1"
+
 
 class DummyOAuth:
-    """Dummy OAuth class for testing."""
-
     async def get_access_token(self):
         return "test_token"
 
@@ -26,43 +26,33 @@ class DummyOAuth:
 
 @pytest.fixture
 def mock_session():
-    """Create a mock aiohttp.ClientSession."""
     return AsyncMock(spec=aiohttp.ClientSession)
 
 
 @pytest.fixture
 def dummy_oauth():
-    """Create a dummy OAuth client."""
     return DummyOAuth()
 
 
 @pytest.fixture
 def syndication_service(mock_session, dummy_oauth):
-    """Create a Syndication service instance for testing."""
     return Syndication(
         session=mock_session,
         oauth=dummy_oauth,
-        base_url="https://edge.social.api.brightcove.com/v1/accounts/",
+        base_url=BASE_URL,
         limit=10,
     )
 
 
 def test_syndication_initialization(syndication_service):
-    """Test Syndication service initializes with correct parameters."""
     assert syndication_service._limit == 10
-    assert (
-        syndication_service.base_url
-        == "https://edge.social.api.brightcove.com/v1/accounts/"
-    )
+    assert syndication_service.base_url == BASE_URL
 
 
 @pytest.mark.asyncio
 async def test_get_all_syndications(syndication_service):
-    """Test get_all_syndications method."""
     with patch.object(
-        syndication_service,
-        "fetch_data",
-        new_callable=AsyncMock,
+        syndication_service, "fetch_data", new_callable=AsyncMock
     ) as mock_fetch:
         mock_fetch.return_value = SyndicationList(root=[])
 
@@ -77,18 +67,12 @@ async def test_get_all_syndications(syndication_service):
 
 @pytest.mark.asyncio
 async def test_get_syndication(syndication_service):
-    """Test get_syndication method."""
     with patch.object(
-        syndication_service,
-        "fetch_data",
-        new_callable=AsyncMock,
+        syndication_service, "fetch_data", new_callable=AsyncMock
     ) as mock_fetch:
         mock_fetch.return_value = SyndicationModel(name="Test", type=Type.google)
 
-        await syndication_service.get_syndication(
-            "account123",
-            "syndication456",
-        )
+        await syndication_service.get_syndication("account123", "syndication456")
 
         mock_fetch.assert_called_once()
         call_args = mock_fetch.call_args
@@ -97,9 +81,166 @@ async def test_get_syndication(syndication_service):
         assert call_args.kwargs["model"] == SyndicationModel
 
 
-def test_base_url_property(syndication_service):
-    """Test base_url property returns correct URL."""
-    assert (
-        syndication_service.base_url
-        == "https://edge.social.api.brightcove.com/v1/accounts/"
-    )
+@pytest.mark.asyncio
+async def test_create_syndication(syndication_service):
+    syndication = SyndicationModel(name="Test Feed", type=Type.google)
+
+    with patch.object(
+        syndication_service, "fetch_data", new_callable=AsyncMock
+    ) as mock_fetch:
+        mock_fetch.return_value = MagicMock(spec=SyndicationModel)
+
+        await syndication_service.create_syndication("account123", syndication)
+
+        mock_fetch.assert_called_once()
+        call_args = mock_fetch.call_args
+        assert "account123" in call_args.kwargs["endpoint"]
+        assert "mrss/syndications" in call_args.kwargs["endpoint"]
+        assert call_args.kwargs["method"] == "POST"
+        assert call_args.kwargs["model"] == SyndicationModel
+        assert call_args.kwargs["payload"] == syndication
+
+
+@pytest.mark.asyncio
+async def test_update_syndication(syndication_service):
+    syndication = SyndicationModel(name="Updated Feed", type=Type.itunes)
+
+    with patch.object(
+        syndication_service, "fetch_data", new_callable=AsyncMock
+    ) as mock_fetch:
+        mock_fetch.return_value = MagicMock(spec=SyndicationModel)
+
+        await syndication_service.update_syndication(
+            "account123", "syn456", syndication
+        )
+
+        mock_fetch.assert_called_once()
+        call_args = mock_fetch.call_args
+        assert "account123" in call_args.kwargs["endpoint"]
+        assert "syn456" in call_args.kwargs["endpoint"]
+        assert call_args.kwargs["method"] == "PUT"
+        assert call_args.kwargs["model"] == SyndicationModel
+        assert call_args.kwargs["payload"] == syndication
+
+
+@pytest.mark.asyncio
+async def test_patch_syndication(syndication_service):
+    syndication = SyndicationModel(name="Patched Feed", type=Type.roku)
+
+    with patch.object(
+        syndication_service, "fetch_data", new_callable=AsyncMock
+    ) as mock_fetch:
+        mock_fetch.return_value = MagicMock(spec=SyndicationModel)
+
+        await syndication_service.patch_syndication("account123", "syn456", syndication)
+
+        mock_fetch.assert_called_once()
+        call_args = mock_fetch.call_args
+        assert "account123" in call_args.kwargs["endpoint"]
+        assert "syn456" in call_args.kwargs["endpoint"]
+        assert call_args.kwargs["method"] == "PATCH"
+        assert call_args.kwargs["model"] == SyndicationModel
+        assert call_args.kwargs["payload"] == syndication
+
+
+@pytest.mark.asyncio
+async def test_delete_syndication(syndication_service, mock_session):
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_session.request.return_value.__aenter__.return_value = mock_response
+
+    await syndication_service.delete_syndication("account123", "syn456")
+
+    mock_session.request.assert_called_once()
+    call_args = mock_session.request.call_args
+    assert call_args.args[0] == "DELETE"
+    assert "account123" in call_args.args[1]
+    assert "syn456" in call_args.args[1]
+    assert "mrss/syndications" in call_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_get_template(syndication_service, mock_session):
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.text = AsyncMock(return_value="<feed>template content</feed>")
+    mock_session.request.return_value.__aenter__.return_value = mock_response
+
+    result = await syndication_service.get_template("account123", "syn456")
+
+    mock_session.request.assert_called_once()
+    call_args = mock_session.request.call_args
+    assert call_args.args[0] == "GET"
+    assert "account123" in call_args.args[1]
+    assert "syn456" in call_args.args[1]
+    assert "template" in call_args.args[1]
+    assert result == "<feed>template content</feed>"
+
+
+@pytest.mark.asyncio
+async def test_upload_template(syndication_service, mock_session):
+    template_content = "<feed>my custom template</feed>"
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_session.request.return_value.__aenter__.return_value = mock_response
+
+    await syndication_service.upload_template("account123", "syn456", template_content)
+
+    mock_session.request.assert_called_once()
+    call_args = mock_session.request.call_args
+    assert call_args.args[0] == "PUT"
+    assert "account123" in call_args.args[1]
+    assert "syn456" in call_args.args[1]
+    assert "template" in call_args.args[1]
+    assert call_args.kwargs.get("data") == template_content
+    assert call_args.kwargs.get("headers", {}).get("Content-Type") == "text/plain"
+
+
+@pytest.mark.asyncio
+async def test_delete_syndication_retries_on_connection_error(
+    syndication_service, mock_session
+):
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_session.request.return_value.__aenter__.side_effect = [
+        aiohttp.ClientConnectionError("Connection failed"),
+        mock_response,
+    ]
+
+    await syndication_service.delete_syndication("account123", "syn456")
+
+    assert mock_session.request.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_template_retries_on_connection_error(
+    syndication_service, mock_session
+):
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.text = AsyncMock(return_value="<feed/>")
+    mock_session.request.return_value.__aenter__.side_effect = [
+        aiohttp.ClientConnectionError("Connection failed"),
+        mock_response,
+    ]
+
+    result = await syndication_service.get_template("account123", "syn456")
+
+    assert result == "<feed/>"
+    assert mock_session.request.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_upload_template_retries_on_connection_error(
+    syndication_service, mock_session
+):
+    mock_response = AsyncMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_session.request.return_value.__aenter__.side_effect = [
+        aiohttp.ClientConnectionError("Connection failed"),
+        mock_response,
+    ]
+
+    await syndication_service.upload_template("account123", "syn456", "<feed/>")
+
+    assert mock_session.request.call_count == 2


### PR DESCRIPTION
Adds all 8 MRSS operations from configuration-openapi.yaml to the Syndication service (get all, get, create, update, patch, delete syndications; get and upload feed templates) and improves the shared networking infrastructure in Base.

Service layer:
- Syndication now covers the full API; base URL corrected to spec value (social.api.brightcove.com)
- Non-JSON operations (DELETE, text GET/PUT) delegate to new Base helpers (_delete, _get_text, _put_text) so Syndication has no knowledge of the network stack

Base layer:
- Extract _delete, _get_text, _put_text as retried, rate-limited helpers for non-JSON endpoints
- Define brightcove_retry once and share it across all network methods
- Catch aiohttp.ClientConnectionError inside each method and re-raise as BrightcoveConnectionError so the retry config references only Brightcove exceptions
- Fix fetch_data payload serialisation: model_dump(mode="json") ensures enum fields serialise to their string values
- Extract _raise_for_status into Base so fetch_data and the direct-session helpers share one error-mapping path

Exceptions:
- Add BrightcoveConnectionError for transport-level failures

Docs:
- Rewrite CLAUDE.MD with full project guidance, fetch_data contract, and the pattern for non-JSON endpoints
- Add configuration-openapi.yaml to brightcove_open_api_specs/

Tests:
- Full coverage for all 8 Syndication methods including retry behaviour
- Direct tests for _raise_for_status and BrightcoveConnectionError translation