### PR TITLE
Remove dead code and deduplicate schemas; fix deprecated ty config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ extend-select = ["I"]
 [tool.ruff.lint.isort]
 known-first-party = ["brightcove_async"]
 
-[tool.ty.src]
-root = "src"
+[tool.ty.environment]
+root = ["src"]
 
 [tool.uv]
 package = true

--- a/src/brightcove_async/schemas/audience_model.py
+++ b/src/brightcove_async/schemas/audience_model.py
@@ -1,69 +1,6 @@
 from __future__ import annotations
 
-from enum import StrEnum
-
 from pydantic import BaseModel, Field
-
-
-class SortLeads(StrEnum):
-    video_id = "video_id"
-    video_name = "video_name"
-    player_id = "player_id"
-    created_at = "created_at"
-
-
-class Sort(StrEnum):
-    video_id = "video_id"
-    video_name = "video_name"
-    tracking_id = "tracking_id"
-    external_id = "external_id"
-    player_id = "player_id"
-    page_url = "page_url"
-    watched = "watched"
-    time_watched = "time_watched"
-    created_at = "created_at"
-    updated_at = "updated_at"
-    is_synced = "is_synced"
-    utm_source = "utm_source"
-    utm_medium = "utm_medium"
-    utm_campaign = "utm_campaign"
-    utm_term = "utm_term"
-    utm_content = "utm_content"
-
-
-class FieldsLeads(StrEnum):
-    video_id = "video_id"
-    video_name = "video_name"
-    external_id = "external_id"
-    first_name = "first_name"
-    last_name = "last_name"
-    email_address = "email_address"
-    business_phone = "business_phone"
-    country = "country"
-    company_name = "company_name"
-    industry = "industry"
-    player_id = "player_id"
-    page_url = "page_url"
-    created_at = "created_at"
-
-
-class Fields(StrEnum):
-    video_id = "video_id"
-    video_name = "video_name"
-    tracking_id = "tracking_id"
-    external_id = "external_id"
-    player_id = "player_id"
-    page_url = "page_url"
-    watched = "watched"
-    time_watched = "time_watched"
-    created_at = "created_at"
-    updated_at = "updated_at"
-    is_synced = "is_synced"
-    utm_source = "utm_source"
-    utm_medium = "utm_medium"
-    utm_campaign = "utm_campaign"
-    utm_term = "utm_term"
-    utm_content = "utm_content"
 
 
 class LeadsResult(BaseModel):

--- a/src/brightcove_async/schemas/params.py
+++ b/src/brightcove_async/schemas/params.py
@@ -52,11 +52,5 @@ class GetLeadsParams(ParamsBase):
     to: str | int | None = None
 
 
-class GetViewEventsParams(ParamsBase):
-    limit: int | None = None
-    offset: int | None = None
-    sort: str | None = None
-    fields: str | None = None
-    where: str | None = None
-    from_: str | int | None = Field(default=None, serialization_alias="from")
-    to: str | int | None = None
+class GetViewEventsParams(GetLeadsParams):
+    pass

--- a/src/brightcove_async/schemas/syndication_model.py
+++ b/src/brightcove_async/schemas/syndication_model.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Optional
 
 from pydantic import BaseModel, Field, RootModel
 
@@ -124,17 +123,4 @@ class Syndication(BaseModel):
 
 
 class SyndicationList(RootModel[list[Syndication]]):
-    pass
-
-
-class ResponseError(BaseModel):
-    error_code: Optional[str] = Field(
-        default=None, description="Application error code"
-    )
-    message: Optional[str] = Field(
-        default=None, description="Application error message"
-    )
-
-
-class ResponseErrorList(RootModel[list[ResponseError]]):
     pass


### PR DESCRIPTION
- params.py: GetViewEventsParams was a byte-for-byte copy of GetLeadsParams; made it inherit instead so future field additions only need one change
- audience_model.py: removed Sort, Fields, SortLeads, FieldsLeads StrEnums that were defined but never imported or used anywhere
- syndication_model.py: removed dead ResponseError and ResponseErrorList models that were never used; removed the Optional import they required
- pyproject.toml: migrated deprecated [tool.ty.src] root setting to the new [tool.ty.environment] root list form