### PR TITLE
Fix Analytics.base_url overriding injected config with hardcoded URL

### DIFF
--- a/src/brightcove_async/services/analytics.py
+++ b/src/brightcove_async/services/analytics.py
@@ -15,10 +15,6 @@ from brightcove_async.services.base import Base
 
 
 class Analytics(Base):
-    @property
-    def base_url(self) -> str:
-        return "https://analytics.api.brightcove.com/v1"
-
     def __init__(
         self,
         session: aiohttp.ClientSession,


### PR DESCRIPTION
Analytics declared a @property base_url returning a hardcoded string, which shadowed the parent Base.base_url property and silently ignored the analytics_base_url value injected from BrightcoveBaseAPIConfig. Removing the override restores the intended behaviour.