### PR TITLE
Fix get_temporary_s3_urls: add missing video_id parameter and unescap…

### DIFF
--- a/src/brightcove_async/services/dynamic_ingest.py
+++ b/src/brightcove_async/services/dynamic_ingest.py
@@ -35,11 +35,10 @@ class DynamicIngest(Base):
     async def get_temporary_s3_urls(
         self,
         account_id: str,
+        video_id: str,
         source_name: str,
     ) -> GetS3UrlsResponse:
         return await self.fetch_data(
-            endpoint=f"{self.base_url}{account_id}/videos/{{video_id}}/upload-urls/{source_name}",
+            endpoint=f"{self.base_url}{account_id}/videos/{video_id}/upload-urls/{source_name}",
             model=GetS3UrlsResponse,
-            method="GET",
-            params={"source_name": source_name},
         )


### PR DESCRIPTION
…e URL

The endpoint used {{video_id}} (escaped f-string braces), which produced a literal `{video_id}` in every request URL, causing all calls to return 404. Also removed the redundant source_name query param that duplicated the path segment.