### PR TITLE
Feat  add rate limit override getter and setter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brightcove_async"
-version = "0.4.0"
+version = "0.5.0"
 description = "An asynchronous client for the Brightcove API."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/brightcove_async/services/base.py
+++ b/src/brightcove_async/services/base.py
@@ -57,14 +57,12 @@ class Base(ABC):
 
     """
 
-    _limit: int = 10
-
     def __init__(
         self,
         session: aiohttp.ClientSession,
         oauth: OAuthClientProtocol,
         base_url: str,
-        limit: int = 10,
+        limit: float = 10,
     ) -> None:
         """Args:.
 
@@ -75,15 +73,54 @@ class Base(ABC):
         self._oauth: OAuthClientProtocol = oauth
         self._session: aiohttp.ClientSession = session
         self._base_url: str = base_url
-        self._limit = limit
+        self._limit: float = limit
         self._limiter: AsyncLimiter | None = None
+        self._time_period: float = 1.0
 
     @property
     def limiter(self) -> AsyncLimiter:
         """AsyncLimiter instance to control the rate of API calls."""
         if self._limiter is None:
-            self._limiter = AsyncLimiter(max_rate=self._limit, time_period=1)
+            self._limiter = AsyncLimiter(
+                max_rate=self._limit, time_period=self._time_period
+            )
         return self._limiter
+
+    @property
+    def time_period(self) -> float:
+        """Time period in seconds for the rate limiter."""
+        return self._time_period
+
+    @time_period.setter
+    def time_period(self, value: float) -> None:
+        """Set the time period for the rate limiter and reset the limiter instance.
+
+        Args:
+            value (float): The new time period in seconds.
+
+        """
+        if value <= 0:
+            raise ValueError("time_period must be greater than 0")
+        self._time_period = value
+        self._limiter = None  # Reset limiter to apply new time period on next access
+
+    @property
+    def max_requests(self) -> float:
+        """Max requests allowed in the time period for the rate limiter."""
+        return self._limit
+
+    @max_requests.setter
+    def max_requests(self, value: float) -> None:
+        """Set the max requests for the rate limiter and reset the limiter instance.
+
+        Args:
+            value (float): The new max requests allowed in the time period.
+
+        """
+        if value <= 0:
+            raise ValueError("max_requests must be greater than 0")
+        self._limit = value
+        self._limiter = None  # Reset limiter to apply new max requests on next access
 
     @property
     def base_url(self) -> str:

--- a/tests/test_base_service.py
+++ b/tests/test_base_service.py
@@ -95,6 +95,40 @@ def test_limiter_singleton(base_service):
     assert limiter1 is limiter2
 
 
+def test_time_period_setter(base_service):
+    """Test time_period setter updates time period and resets limiter."""
+    base_service.time_period = 2
+
+    assert base_service.time_period == 2
+    assert base_service._limiter is None  # Limiter should be reset
+
+
+def test_time_period_setter_invalid_value(base_service):
+    """Test time_period setter raises ValueError for non-positive values."""
+    with pytest.raises(ValueError):
+        base_service.time_period = 0
+
+    with pytest.raises(ValueError):
+        base_service.time_period = -1
+
+
+def test_max_requests_setter(base_service):
+    """Test max_requests setter updates max requests and resets limiter."""
+    base_service.max_requests = 20
+
+    assert base_service.max_requests == 20
+    assert base_service._limiter is None  # Limiter should be reset
+
+
+def test_max_requests_setter_invalid_value(base_service):
+    """Test max_requests setter raises ValueError for non-positive values."""
+    with pytest.raises(ValueError):
+        base_service.max_requests = 0
+
+    with pytest.raises(ValueError):
+        base_service.max_requests = -5
+
+
 @pytest.mark.asyncio
 async def test_raise_for_status_passes_on_success(base_service):
     """Test _raise_for_status does not raise when response is successful."""

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [[package]]
@@ -115,7 +115,7 @@ wheels = [
 
 [[package]]
 name = "brightcove-async"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
This pull request introduces enhancements to the rate limiting functionality in the `Base` service class, allowing dynamic configuration of both the maximum number of requests and the time period for the rate limiter. It also adds comprehensive tests for these new features. The version number is incremented to reflect these improvements.

**Rate limiter configurability and validation:**

* Added `time_period` and `max_requests` properties (with corresponding setters) to the `Base` class in `base.py`, allowing dynamic adjustment of the rate limiter's time window and maximum requests. Setters reset the limiter and validate that values are positive. (`src/brightcove_async/services/base.py` [src/brightcove_async/services/base.pyL78-R124](diffhunk://#diff-ac86019f944bb1b40d89ac6dfbca0131d72a426b7bde050aaf51d76882e81906L78-R124))
* Modified the limiter instantiation to use the configurable `time_period` property instead of a hardcoded value. (`src/brightcove_async/services/base.py` [src/brightcove_async/services/base.pyL78-R124](diffhunk://#diff-ac86019f944bb1b40d89ac6dfbca0131d72a426b7bde050aaf51d76882e81906L78-R124))

**Testing improvements:**

* Added tests in `test_base_service.py` to verify correct behavior of the `time_period` and `max_requests` setters, including validation for non-positive values. (`tests/test_base_service.py` [tests/test_base_service.pyR98-R131](diffhunk://#diff-11f6e93e6bd5a022a14433714cc2dd9eab5fc058aeab7f9a18e3d7f135693468R98-R131))

**Version bump:**

* Incremented package version from 0.4.0 to 0.5.0 to reflect the new functionality. (`pyproject.toml` [pyproject.tomlL3-R3](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3))