### PR TITLE
Fix 6 correctness bugs from code review

### DIFF
--- a/src/brightcove_async/exceptions.py
+++ b/src/brightcove_async/exceptions.py
@@ -41,6 +41,10 @@ class BrightcoveClientError(BrightcoveError):
 class BrightcoveAuthError(BrightcoveClientError):
     """Raised when authentication with the Brightcove API fails."""
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.token_invalidated: bool = False
+
 
 class BrightcoveForbiddenError(BrightcoveClientError):
     """Raised when the caller lacks permission for the requested resource."""

--- a/src/brightcove_async/oauth/oauth.py
+++ b/src/brightcove_async/oauth/oauth.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 import aiohttp
@@ -22,6 +23,7 @@ class OAuthClient:
         self._request_time = 0.0
         self._token_life = 240.0  # Token expires after 4 minutes
         self._session: aiohttp.ClientSession = session
+        self._token_lock = asyncio.Lock()
 
     def invalidate_token(self) -> None:
         self._access_token = None
@@ -49,6 +51,10 @@ class OAuthClient:
         ):
             response.raise_for_status()
             json_data = await response.json()
+            if not isinstance(json_data, dict):
+                raise ValueError(
+                    f"OAuth server returned unexpected response type: {type(json_data).__name__}"
+                )
             access_token = json_data.get("access_token")
             if not access_token:
                 raise ValueError("OAuth server returned no access_token")
@@ -56,11 +62,17 @@ class OAuthClient:
             self._request_time = time.time()
 
     async def get_access_token(self) -> str:
-        if (
-            not self._access_token
-            or time.time() - self._request_time > self._token_life
-        ):
-            await self._get_access_token()
+        # Fast path: token is valid, no lock needed
+        if self._access_token and time.time() - self._request_time <= self._token_life:
+            return self._access_token
+
+        async with self._token_lock:
+            # Re-check under the lock in case another coroutine already refreshed
+            if (
+                not self._access_token
+                or time.time() - self._request_time > self._token_life
+            ):
+                await self._get_access_token()
 
         if not self._access_token:
             raise ValueError("Failed to fetch access token.")

--- a/src/brightcove_async/services/base.py
+++ b/src/brightcove_async/services/base.py
@@ -1,12 +1,16 @@
+import contextlib
 import logging
 from abc import ABC
+from http import HTTPStatus
 from typing import TypeVar
 
 import aiohttp
 from aiolimiter import AsyncLimiter
 from pydantic import BaseModel
 from tenacity import (
+    RetryCallState,
     retry,
+    retry_if_exception,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
@@ -24,15 +28,31 @@ from brightcove_async.protocols import OAuthClientProtocol
 T = TypeVar("T", bound=BaseModel)
 logger = logging.getLogger(__name__)
 
+
+def _retry_after_wait(retry_state: RetryCallState) -> float:
+    """Use the Retry-After header value from a 429 response when available."""
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    if isinstance(exc, BrightcoveTooManyRequestsError):
+        retry_after = exc.details.get("retry_after")
+        if retry_after is not None:
+            return float(retry_after)
+    exp = wait_exponential(multiplier=1, min=1, max=10)
+    return exp(retry_state)
+
+
 brightcove_retry = retry(
-    retry=retry_if_exception_type(
-        (
-            BrightcoveConnectionError,
-            BrightcoveAuthError,
-            BrightcoveTooManyRequestsError,
-        ),
+    retry=(
+        retry_if_exception_type(
+            (BrightcoveConnectionError, BrightcoveTooManyRequestsError),
+        )
+        | retry_if_exception(
+            # Only retry auth errors when the token was actually invalidated
+            # (oauth-managed headers). Custom-supplied headers cannot be
+            # refreshed — retrying would just repeat the same 401.
+            lambda e: isinstance(e, BrightcoveAuthError) and e.token_invalidated,
+        )
     ),
-    wait=wait_exponential(multiplier=1, min=1, max=3),
+    wait=_retry_after_wait,
     stop=stop_after_attempt(5),
 )
 
@@ -139,6 +159,11 @@ class Base(ABC):
                 error_details = {"response_body": error_body}
             except Exception:
                 pass
+            if e.status == HTTPStatus.TOO_MANY_REQUESTS:
+                retry_after_raw = response.headers.get("Retry-After")
+                if retry_after_raw is not None:
+                    with contextlib.suppress(ValueError):
+                        error_details["retry_after"] = int(retry_after_raw)
             exc_class: type[BrightcoveError] = map_status_code_to_exception(e.status)
             raise exc_class(
                 message=str(e.message),
@@ -166,7 +191,8 @@ class Base(ABC):
         headers: dict | None = None,
         payload: BaseModel | None = None,
     ) -> T:
-        if headers is None:
+        using_oauth_headers = headers is None
+        if using_oauth_headers:
             try:
                 headers = await self._oauth.headers
             except _OAUTH_FETCH_ERRORS as e:
@@ -197,8 +223,10 @@ class Base(ABC):
                 await self._raise_for_status(response, endpoint)
                 json_data = await response.json()
                 return model.model_validate(json_data, strict=False)
-        except BrightcoveAuthError:
-            self._oauth.invalidate_token()
+        except BrightcoveAuthError as e:
+            if using_oauth_headers:
+                self._oauth.invalidate_token()
+                e.token_invalidated = True
             raise
         except aiohttp.ClientConnectionError as e:
             raise BrightcoveConnectionError(message=str(e), endpoint=endpoint) from e
@@ -215,8 +243,9 @@ class Base(ABC):
                 self._session.request("DELETE", endpoint, headers=headers) as response,
             ):
                 await self._raise_for_status(response, endpoint)
-        except BrightcoveAuthError:
+        except BrightcoveAuthError as e:
             self._oauth.invalidate_token()
+            e.token_invalidated = True
             raise
         except aiohttp.ClientConnectionError as e:
             raise BrightcoveConnectionError(message=str(e), endpoint=endpoint) from e
@@ -234,8 +263,9 @@ class Base(ABC):
             ):
                 await self._raise_for_status(response, endpoint)
                 return await response.text()
-        except BrightcoveAuthError:
+        except BrightcoveAuthError as e:
             self._oauth.invalidate_token()
+            e.token_invalidated = True
             raise
         except aiohttp.ClientConnectionError as e:
             raise BrightcoveConnectionError(message=str(e), endpoint=endpoint) from e
@@ -255,8 +285,9 @@ class Base(ABC):
                 ) as response,
             ):
                 await self._raise_for_status(response, endpoint)
-        except BrightcoveAuthError:
+        except BrightcoveAuthError as e:
             self._oauth.invalidate_token()
+            e.token_invalidated = True
             raise
         except aiohttp.ClientConnectionError as e:
             raise BrightcoveConnectionError(message=str(e), endpoint=endpoint) from e

--- a/src/brightcove_async/services/cms.py
+++ b/src/brightcove_async/services/cms.py
@@ -9,6 +9,7 @@ from brightcove_async.schemas.cms_model import (
     Channel,
     ChannelAffiliateList,
     ChannelList,
+    Contract,
     ContractList,
     CreateVideoRequestBodyFields,
     CustomFields,
@@ -65,6 +66,8 @@ class CMS(Base):
             payload=video_data,
         )
 
+    _page_concurrency = 10
+
     async def get_videos_for_account(
         self,
         account_id: str,
@@ -90,20 +93,35 @@ class CMS(Base):
             else number_of_pages
         )
 
-        tasks = [
-            self.fetch_data(
-                endpoint=f"{self.base_url}{account_id}/videos",
-                model=VideoArray,
-                params={
-                    **(params.serialize_params() if params else {}),
-                    "limit": page_size,
-                    "offset": i * page_size,
-                },
-            )
-            for i in range(total_pages)
-        ]
+        # Strip pagination keys — this method owns offset/limit for each page.
+        base_params = (
+            {
+                k: v
+                for k, v in params.serialize_params().items()
+                if k not in ("limit", "offset")
+            }
+            if params
+            else {}
+        )
 
-        pages = await asyncio.gather(*tasks)
+        semaphore = asyncio.Semaphore(self._page_concurrency)
+
+        async def fetch_page(i: int) -> VideoArray:
+            async with semaphore:
+                return await self.fetch_data(
+                    endpoint=f"{self.base_url}{account_id}/videos",
+                    model=VideoArray,
+                    params={**base_params, "limit": page_size, "offset": i * page_size},
+                )
+
+        tasks = [asyncio.ensure_future(fetch_page(i)) for i in range(total_pages)]
+
+        try:
+            pages = await asyncio.gather(*tasks)
+        except Exception:
+            for t in tasks:
+                t.cancel()
+            raise
 
         for page in pages:
             results.root.extend(page.root)
@@ -287,10 +305,10 @@ class CMS(Base):
         account_id: str,
         channel_id: str,
         contract_id: str,
-    ) -> ContractList:
+    ) -> Contract:
         return await self.fetch_data(
             endpoint=f"{self.base_url}{account_id}/channels/{channel_id}/contracts/{contract_id}",
-            model=ContractList,
+            model=Contract,
         )
 
     async def list_shares(


### PR DESCRIPTION
## Summary

Fixes all correctness bugs surfaced in the [code review](https://github.com/Winne004/brightcove_async/blob/main/CLAUDE.md):

- **`cms.get_contract` always raised `ValidationError`** — used `ContractList` (a list root model) for an endpoint that returns a single object; changed to `Contract` with the correct return type
- **OAuth token stampede** — `get_access_token` had no lock; N concurrent callers that all saw an expired token all fired independent OAuth requests. Added double-checked locking (`asyncio.Lock`) so only one refresh request fires per expiry cycle
- **Malformed OAuth 200 body caused `AttributeError`** — added an `isinstance(json_data, dict)` guard in `_get_access_token` so non-dict responses raise `ValueError` (which is already in `_OAUTH_FETCH_ERRORS`) rather than an unhandled `AttributeError`
- **`get_videos_for_account` silently discarded caller's `offset`/`limit`** — stripped those keys from params before building per-page params so callers can't accidentally corrupt pagination; also added a `Semaphore(10)` to cap concurrent page fetches and cancels sibling tasks when any page raises
- **Custom-headers auth retry wasted 5 attempts** — `fetch_data` with explicit `headers` would retry a 401 five times with the same stale headers. `BrightcoveAuthError` is now only marked retriable when using oauth-managed headers (via a `token_invalidated` flag on the exception)
- **`Retry-After` header ignored on 429** — `brightcove_retry` now reads `Retry-After` from `BrightcoveTooManyRequestsError.details` and uses it as the wait delay, falling back to exponential backoff when absent

## Test plan

- [ ] All 203 existing tests pass (`uv run pytest`)
- [ ] Lint, format, type checks pass (`uv run ruff check --fix`, `uv run ruff format`, `uv run ty check`)
- [ ] `get_contract` can be called without raising `ValidationError`
- [ ] Concurrent callers that all hit a token expiry produce only one OAuth refresh request
- [ ] `get_videos_for_account` with a `q` param fetches all pages correctly without duplicating the first page

🤖 Generated with [Claude Code](https://claude.com/claude-code)