### PR TITLE
fix: reset session to None on exit and re-assign on re-entry for external sessions

### DIFF
--- a/src/brightcove_async/client.py
+++ b/src/brightcove_async/client.py
@@ -112,7 +112,7 @@ class BrightcoveClient:
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
-        if self._session is not None and self._external_session is None: 
+        if self._session is not None and self._external_session is None:
             await self._session.close()
         self._session = None
         self._services.clear()

--- a/src/brightcove_async/client.py
+++ b/src/brightcove_async/client.py
@@ -103,7 +103,9 @@ class BrightcoveClient:
         return self._get_service("audience", Audience)
 
     async def __aenter__(self) -> Self:
-        if self._session is None:
+        if self._external_session is not None:
+            self._session = self._external_session
+        else:
             self._session = aiohttp.ClientSession(
                 connector=aiohttp.TCPConnector(limit=100),
             )
@@ -112,6 +114,6 @@ class BrightcoveClient:
     async def __aexit__(self, exc_type, exc, tb) -> None:
         if self._session and not self._external_session:
             await self._session.close()
-            self._session = None
+        self._session = None
         self._services.clear()
         self._oauth = None

--- a/src/brightcove_async/client.py
+++ b/src/brightcove_async/client.py
@@ -112,7 +112,7 @@ class BrightcoveClient:
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
-        if self._session and not self._external_session:
+        if self._session is not None and self._external_session is None: 
             await self._session.close()
         self._session = None
         self._services.clear()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -317,3 +317,40 @@ async def test_client_reentry_creates_new_session():
         assert len(sessions) == 2
         sessions[0].close.assert_awaited_once()
         sessions[1].close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_external_session_reusable_across_context_entries():
+    """Re-entering with an external session after exit should restore the session."""
+    from brightcove_async.registry import ServiceConfig
+    from brightcove_async.services.cms import CMS
+
+    services_registry = {
+        "cms": ServiceConfig(cls=CMS, base_url="cms_url", requests_per_second=4),
+    }
+    external_session = create_autospec(aiohttp.ClientSession, instance=True)
+    external_session.close = AsyncMock()
+
+    client = BrightcoveClient(
+        services_registry=services_registry,
+        client_id="id",
+        client_secret="secret",
+        oauth_cls=DummyOAuth,
+        session=external_session,
+    )
+
+    # First entry
+    async with client as c:
+        assert c._session is external_session
+
+    # Session should be None after exit
+    assert client._session is None
+
+    # Second entry — should restore the external session, not create a new one
+    with patch("aiohttp.ClientSession") as MockSession:
+        async with client as c:
+            assert c._session is external_session
+            MockSession.assert_not_called()  # No new session created
+
+    # External session should never be closed by the client
+    external_session.close.assert_not_called()


### PR DESCRIPTION
## Summary

- **Bug**: When an external `aiohttp.ClientSession` was provided, `__aexit__` left `self._session` pointing at the (potentially closed) external session. On re-entry, `__aenter__` saw `self._session is not None` and skipped re-assigning, routing all subsequent calls through the closed session and raising `RuntimeError: Session is closed`.
- **Fix**: `__aexit__` now unconditionally sets `self._session = None` (regardless of who owns the session). `__aenter__` always re-assigns from `_external_session` if one was provided, otherwise creates a fresh `ClientSession`.
- **Test**: Added `test_external_session_reusable_across_context_entries` to cover the re-entry scenario — verifies session is `None` after exit, restored on re-entry, no new `ClientSession` is created, and the external session is never closed by the client.

## Test plan

- [x] `uv run pytest` — 204 tests pass (including new regression test)
- [x] `uv run ruff check --fix` — no issues
- [x] `uv run ruff format` — no changes
- [x] `uv run ty check` — no issues
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)