### PR TITLE
fix: remove dead kwargs field from ServiceConfig

### DIFF
--- a/src/brightcove_async/registry.py
+++ b/src/brightcove_async/registry.py
@@ -15,7 +15,6 @@ class ServiceConfig:
     cls: type[Base]
     base_url: str
     requests_per_second: int = 10
-    kwargs: dict | None = None
 
 
 def build_service_registry(config: BrightcoveBaseAPIConfig) -> dict[str, ServiceConfig]:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -12,13 +12,11 @@ def test_service_config_creation():
         cls=CMS,
         base_url="https://cms.api.brightcove.com/v1/accounts/",
         requests_per_second=4,
-        kwargs={"test": "value"},
     )
 
     assert config.cls == CMS
     assert config.base_url == "https://cms.api.brightcove.com/v1/accounts/"
     assert config.requests_per_second == 4
-    assert config.kwargs == {"test": "value"}
 
 
 def test_service_config_defaults():
@@ -29,7 +27,6 @@ def test_service_config_defaults():
     )
 
     assert config.requests_per_second == 10
-    assert config.kwargs is None
 
 
 def test_build_service_registry():


### PR DESCRIPTION
## Summary

- Removes the `kwargs: dict | None = None` field from the `ServiceConfig` dataclass in `registry.py`
- This field was never read by `client.py`'s `_get_service` method, meaning any value set by a caller was silently ignored — a silent footgun
- Updates `tests/test_registry.py` to remove the two references that constructed `ServiceConfig` with `kwargs=` and asserted on `.kwargs`

## Test plan

- [x] All 203 existing tests pass (`uv run pytest`)
- [x] `uv run ruff check --fix` — no issues
- [x] `uv run ruff format` — no changes
- [x] `uv run ty check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)