### PR TITLE
fix(cms): use correct Contract model for get_contract and skip count fetch when number_of_pages is provided

### DIFF
--- a/src/brightcove_async/services/cms.py
+++ b/src/brightcove_async/services/cms.py
@@ -9,6 +9,7 @@ from brightcove_async.schemas.cms_model import (
     Channel,
     ChannelAffiliateList,
     ChannelList,
+    Contract,
     ContractList,
     CreateVideoRequestBodyFields,
     CustomFields,
@@ -77,18 +78,14 @@ class CMS(Base):
         if page_size > self._page_limit:
             raise ValueError("page_size must be less than or equal to 100")
 
-        video_count_params = GetVideoCountParams(q=params.q) if params else None
-
-        count = await self.get_video_count(account_id, params=video_count_params)
-
-        if count.count is None or count.count == 0:
-            return results
-
-        total_pages = (
-            (count.count + page_size - 1) // page_size
-            if number_of_pages is None
-            else number_of_pages
-        )
+        if number_of_pages is not None:
+            total_pages = number_of_pages
+        else:
+            video_count_params = GetVideoCountParams(q=params.q) if params else None
+            count = await self.get_video_count(account_id, params=video_count_params)
+            if count.count is None or count.count == 0:
+                return results
+            total_pages = (count.count + page_size - 1) // page_size
 
         tasks = [
             self.fetch_data(
@@ -287,10 +284,10 @@ class CMS(Base):
         account_id: str,
         channel_id: str,
         contract_id: str,
-    ) -> ContractList:
+    ) -> Contract:
         return await self.fetch_data(
             endpoint=f"{self.base_url}{account_id}/channels/{channel_id}/contracts/{contract_id}",
-            model=ContractList,
+            model=Contract,
         )
 
     async def list_shares(

--- a/tests/test_cms_service.py
+++ b/tests/test_cms_service.py
@@ -9,6 +9,7 @@ from brightcove_async.schemas.cms_model import (
     Channel,
     ChannelAffiliateList,
     ChannelList,
+    Contract,
     ContractList,
     CreateVideoRequestBodyFields,
     CustomFields,
@@ -342,9 +343,9 @@ async def test_list_contracts(cms_service):
 
 @pytest.mark.asyncio
 async def test_get_contract(cms_service):
-    """Test get_contract method."""
+    """Test get_contract method uses Contract model (not ContractList)."""
     with patch.object(cms_service, "fetch_data", new_callable=AsyncMock) as mock_fetch:
-        mock_fetch.return_value = ContractList(root=[])
+        mock_fetch.return_value = Contract()
 
         await cms_service.get_contract(
             "account123",
@@ -355,6 +356,7 @@ async def test_get_contract(cms_service):
         mock_fetch.assert_called_once()
         call_args = mock_fetch.call_args
         assert "contract123" in call_args.kwargs["endpoint"]
+        assert call_args.kwargs["model"] == Contract
 
 
 @pytest.mark.asyncio
@@ -385,7 +387,22 @@ async def test_get_video_fields(cms_service):
 async def test_get_videos_for_account_pagination(cms_service):
     """Test get_videos_for_account handles pagination correctly."""
     with patch.object(cms_service, "fetch_data", new_callable=AsyncMock) as mock_fetch:
-        # Mock count response
+        mock_fetch.return_value = VideoArray(root=[])
+
+        await cms_service.get_videos_for_account(
+            "account123",
+            page_size=25,
+            number_of_pages=2,
+        )
+
+        # Should have fetched 2 pages
+        assert mock_fetch.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_videos_for_account_skips_count_when_pages_provided(cms_service):
+    """Test get_videos_for_account does NOT call get_video_count when number_of_pages is given."""
+    with patch.object(cms_service, "fetch_data", new_callable=AsyncMock) as mock_fetch:
         mock_fetch.return_value = VideoArray(root=[])
 
         with patch.object(
@@ -393,15 +410,13 @@ async def test_get_videos_for_account_pagination(cms_service):
             "get_video_count",
             new_callable=AsyncMock,
         ) as mock_count:
-            mock_count.return_value = VideoCount(count=50)
-
             await cms_service.get_videos_for_account(
                 "account123",
                 page_size=25,
                 number_of_pages=2,
             )
 
-            # Should have fetched 2 pages
+            mock_count.assert_not_called()
             assert mock_fetch.call_count == 2
 
 


### PR DESCRIPTION
## Summary

- `get_contract` was returning `ContractList` but the Brightcove API returns a single contract object for this endpoint — corrected to return `Contract`
- `get_videos_for_account` was unconditionally calling `get_video_count` even when `number_of_pages` was explicitly provided, causing an unnecessary network round-trip — the count fetch is now skipped when `number_of_pages` is supplied
- Tests updated to assert the correct model is passed to `fetch_data`, and a new test verifies `get_video_count` is not called when pages are explicitly provided

## Test plan

- [x] `uv run pytest` — 204 tests pass
- [x] `uv run ruff check --fix` — no issues
- [x] `uv run ruff format` — no changes
- [x] `uv run ty check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)