### PR TITLE
fix(oauth): add asyncio.Lock to prevent concurrent token double-fetch

### DIFF
--- a/src/brightcove_async/oauth/oauth.py
+++ b/src/brightcove_async/oauth/oauth.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 import aiohttp
@@ -22,6 +23,7 @@ class OAuthClient:
         self._request_time = 0.0
         self._token_life = 240.0  # Token expires after 4 minutes
         self._session: aiohttp.ClientSession = session
+        self._lock: asyncio.Lock = asyncio.Lock()
 
     def invalidate_token(self) -> None:
         self._access_token = None
@@ -56,16 +58,17 @@ class OAuthClient:
             self._request_time = time.time()
 
     async def get_access_token(self) -> str:
-        if (
-            not self._access_token
-            or time.time() - self._request_time > self._token_life
-        ):
-            await self._get_access_token()
+        async with self._lock:
+            if (
+                not self._access_token
+                or time.time() - self._request_time > self._token_life
+            ):
+                await self._get_access_token()
 
-        if not self._access_token:
-            raise ValueError("Failed to fetch access token.")
+            if not self._access_token:
+                raise ValueError("Failed to fetch access token.")
 
-        return self._access_token
+            return self._access_token
 
     @property
     async def headers(self) -> dict[str, str]:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -146,3 +146,26 @@ async def test_http_error_response(oauth_client, mock_session):
 
     with pytest.raises(ValueError, match="access_token"):
         await oauth_client.get_access_token()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_token_refresh_only_fetches_once(oauth_client, mock_session):
+    """Concurrent callers with an expired token should only trigger one refresh."""
+    import asyncio
+
+    oauth_client._access_token = "old_token"
+    oauth_client._request_time = time.time() - 300  # expired
+
+    mock_response = AsyncMock()
+    mock_response.json = AsyncMock(return_value={"access_token": "new_token"})
+    mock_response.raise_for_status = MagicMock()
+    mock_session.post.return_value.__aenter__.return_value = mock_response
+
+    # Run two concurrent token fetches
+    results = await asyncio.gather(
+        oauth_client.get_access_token(),
+        oauth_client.get_access_token(),
+    )
+
+    assert all(r == "new_token" for r in results)
+    assert mock_session.post.call_count == 1  # Only one actual OAuth call


### PR DESCRIPTION
## Summary

- Wraps the token validity check and `_get_access_token()` call in `OAuthClient.get_access_token` with an `asyncio.Lock`
- Prevents concurrent coroutines with an expired token from racing to fetch a new token, resulting in multiple redundant OAuth HTTP requests
- Adds a test (`test_concurrent_token_refresh_only_fetches_once`) that runs two concurrent `get_access_token()` calls and asserts exactly one POST to the token endpoint

## Test plan

- [x] `uv run pytest` — all 204 tests pass
- [x] `uv run ruff check --fix` — no issues
- [x] `uv run ruff format` — no changes needed
- [x] `uv run ty check` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)