### PR TITLE
ci: auto-release on version change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Auto Release on Version Change
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from pyproject.toml
+        id: version
+        run: |
+          VERSION=$(grep -m1 '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release already exists
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ steps.version.outputs.tag }}" &>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` — a new workflow that runs on every push to `main` and creates a GitHub release when the version in `pyproject.toml` has not yet been released.
- The release tag is derived directly from the `version` field (e.g. `v0.6.0`); if the tag already exists the creation step is skipped, making the workflow fully idempotent.
- Uses `--generate-notes` so GitHub auto-populates release notes from merged PRs since the previous tag.
- No changes to the existing `package-publish.yml` — that workflow already triggers on `release: published`, so PyPI publishing continues to work automatically once a release is created.

## How it works

1. Extract `version` from `pyproject.toml` on every push to `main`.
2. Check whether a GitHub release for `v<version>` already exists via `gh release view`.
3. If not, run `gh release create` with auto-generated notes.
4. The new release event fires `package-publish.yml`, which builds and publishes to PyPI.

## Reviewer notes

- Requires `contents: write` permission (already scoped to the job, not the whole workflow).
- The only secret needed is the built-in `github.token` — no new secrets required.
- To cut a release, bump the version in `pyproject.toml`, open a PR, and merge — the rest is automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)