### PR TITLE
feat(policy): add Policy API service for policy keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - Per-service rate limiting via `aiolimiter`.
 - Automatic retries for transient failures (connection drops, `401`, `429`) with `tenacity`, including `Retry-After` support on rate-limited responses.
 - Brightcove HTTP errors mapped to a typed exception hierarchy.
-- Coverage for the CMS, Analytics, Audience, Syndication, Dynamic Ingest, Ingest Profiles, Image, and Live APIs.
+- Coverage for the CMS, Analytics, Audience, Syndication, Dynamic Ingest, Ingest Profiles, Image, Live, and Policy APIs.
 
 ## Installation
 
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-Services are exposed as properties on the client (`bc.cms`, `bc.analytics`, `bc.audience`, `bc.syndication`, `bc.dynamic_ingest`, `bc.ingest_profiles`, `bc.images`, `bc.live`) and are created lazily on first access.
+Services are exposed as properties on the client (`bc.cms`, `bc.analytics`, `bc.audience`, `bc.syndication`, `bc.dynamic_ingest`, `bc.ingest_profiles`, `bc.images`, `bc.live`, `bc.policy`) and are created lazily on first access.
 
 Schema models can be imported from the top-level `brightcove_async.schemas` namespace or directly from the submodule:
 
@@ -328,6 +328,7 @@ Each service has its own request-per-second budget enforced by an `AsyncLimiter`
 | `ingest_profiles` | `get_ingest_profiles` |
 | `images` | `transform_image` |
 | `live` | Jobs: `list_jobs`, `create_job`, `get_job`, `update_job`, `finish_job`, `start_job`, `stop_job`, `clip_job`, `force_failover`, `reset_origin`, `get_thumbnail`, `insert_cuepoint`, `get_job_metrics`, `get_supported_metrics`, `get_job_notifications`, `get_account_notifications`. Scheduler: `list_schedules`, `get_autostop_schedule`, `create_jobstartstop_schedule`, `get_jobstartstop_schedule`, `update_jobstartstop_schedule`, `delete_jobstartstop_schedule`, `list_scheduled_clips`, `create_scheduled_clip`, `get_scheduled_clip`, `update_scheduled_clip`, `delete_scheduled_clip`. Playback: `create_playback_token`, `generate_batch_sources`, `generate_playback_url`. Sessions: `get_session`, `get_session_events`, `get_resource_sessions`. SSAI: `list_ad_configs`, `create_ad_config`, `get_ad_config`, `update_ad_config`, `delete_ad_config`. Settings/misc: `list_cdn_tokens`, `healthcheck` |
+| `policy` | `create_policy_key`, `get_policy_key` |
 
 ## Development
 

--- a/brightcove_open_api_specs/policy.yaml
+++ b/brightcove_open_api_specs/policy.yaml
@@ -1,0 +1,326 @@
+openapi: 3.0.3
+x-bc-implicit-head: true
+x-bc-implicit-options: true
+x-bc-upstream: 'https://backend_server'
+info:
+  title: Policy API Reference
+  description: |-
+    Reference for the Brightcove Policy API, used to create policy keys to
+    access the Playback API. This API is used to generate keys to access the
+    Playback API outside the context of a Brightcove Player.
+    <br><br><strong>Notes:</strong><ul><li>Policy keys are generated
+    automatically for Brightcove Players.</li><li>To test API requests, you can
+    use our <a href="/getting-started/concepts-testing-tools-brightcove-apis.html"
+    target="_blank">API Testing Tools</a></li></ul>
+
+    For additional in-depth guides to features of the API, see the **[general documentation](/policy/index.html)**.
+
+     **Base URL**: https://policy.api.brightcove.com/v1
+  version: 1.0.0
+  x-bc-access: public
+servers:
+  - url: 'https://policy.api.brightcove.com/v1'
+    variables: {}
+tags:
+  - name: Policy
+    description: Operations for creating and retrieving policy keys for Brightcove Players.
+paths:
+  '/accounts/{{account_id}}/policy_keys':
+    post:
+      tags:
+        - Policy
+      summary: Create a Policy Key
+      description: |-
+        'Create a new policy key to access the Playback API '
+      operationId: CreateAPolicyKey
+      security:
+        - BC_OAuth2:
+          - video-cloud/player/all
+      parameters:
+        - name: account_id
+          in: path
+          description: Video Cloud account ID
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Content-Type
+          in: header
+          description: 'Content-Type: application/json'
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          description: 'Authorization: Bearer access_token (see [Getting Access Tokens](/oauth/guides/getting-access-tokens.html))'
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      requestBody:
+        description: Create a new policy key to access the Playback API
+        content:
+          application/json:
+            schema:
+              description: Create a new policy key to access the Playback API
+              $ref: '#/components/schemas/CreateAPolicyKeybody'
+        required: true
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatePolicyKeyResponse'
+        '400':
+          description: >-
+            NOT_AVAILABLE: The resource you are requesting is temporarily unavailable
+        '401':
+          description: >-
+            UNAUTHORIZED: Authentication failed; check to make sure your policy
+            key is correct
+        '404':
+          description: >-
+            RESOURCE_NOT_FOUND: The api could not find the resource you requested
+        '500':
+          description: |-
+            UNKNOWN: Issue in Brightcove system; try again later.
+            TIMEOUT: Server likely too busy; try again later.
+      deprecated: false
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+  '/accounts/{{account_id}}/policy_keys/{key_string}':
+    get:
+      tags:
+        - Policy
+      summary: Get Policy
+      description: 'Get a policy key associated with a policy key string '
+      operationId: GetPolicy
+      security:
+        - BC_OAuth2:
+          - video-cloud/player/read
+      parameters:
+        - name: account_id
+          in: path
+          description: Video Cloud account ID
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: key_string
+          in: path
+          description: the key string for the policy
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Content-Type
+          in: header
+          description: 'Content-Type: application/json'
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+        - name: Authorization
+          in: header
+          description: 'Authorization: Bearer access_token (see [Getting Access Tokens](/oauth/guides/getting-access-tokens.html))'
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: '200'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPolicy200'
+        '400':
+          description: >-
+            NOT_AVAILABLE: The resource you are requesting is temporarily unavailable
+        '401':
+          description: >-
+            UNAUTHORIZED: Authentication failed; check to make sure your policy
+            key is correct
+        '404':
+          description: >-
+            RESOURCE_NOT_FOUND: The api could not find the resource you requested
+        '500':
+          description: |-
+            UNKNOWN: Issue in Brightcove system; try again later.
+            TIMEOUT: Server likely too busy; try again later.
+      deprecated: false
+      x-operation-settings:
+        CollectParameters: false
+        AllowDynamicQueryParameters: false
+        AllowDynamicFormParameters: false
+        IsMultiContentStreaming: false
+components:
+  schemas:
+    CreateAPolicyKeybody:
+      title: Create_a_Policy_KeyBody
+      required:
+        - key-data
+      type: object
+      properties:
+        key-data:
+          description: Data for the policy key
+          $ref: '#/components/schemas/CreateAPolicyKeybody.key-data'
+    CreateAPolicyKeybody.key-data:
+      title: Create_a_Policy_KeyBody.key-data
+      required:
+        - account-id
+      type: object
+      properties:
+        account-id:
+          type: string
+          description: Video Cloud account id
+        apis:
+          type: array
+          items:
+            type: string
+          description: >-
+            Array of APIs that are permitted for this key (currently
+            &quot;search&quot; is the only one available - this must be included
+            to use the search functionality for the Playback API)
+        allowed-domains:
+          type: array
+          items:
+            type: string
+          description: 'For domain restriction, the domains this key will work on'
+        require-ad-config:
+          type: boolean
+          description: >-
+            Whether Playback API requests require an ad-config-id URL parameter
+            for server-side ad insertion
+        geo:
+          description: Map of geo-filtering properties
+          $ref: '#/components/schemas/CreateAPolicyKeybody.key-data.geo'
+    CreateAPolicyKeybody.key-data.geo:
+      title: Create_a_Policy_KeyBody.key-data.geo
+      type: object
+      properties:
+        countries:
+          type: array
+          items:
+            type: string
+          description: >-
+            Array of ISO 3166 list of 2- or 4-letter codes in lower-case (search
+            for &quot;country codes&quot;)
+        exclude_countries:
+          type: boolean
+          description: >-
+            If true, country array is treated as a list of countries excluded
+            from viewing. If false, the country array is a list of countries
+            included for viewing.
+    CreatePolicyKeyResponse:
+      title:  Create Policy Key Response
+      required:
+        - key_string
+        - key-data
+      type: object
+      properties:
+        key_string:
+          type: string
+          description: The policy key string
+        key-data:
+          description: Map of key data prescribing the policy
+          $ref: '#/components/schemas/KeyData'
+      example: {
+          "key-string": "BCpkADawqM1IftwCYR6HsNBjvIoCgGZdeSz6f1zJYW4mGg7YFiCIejFI1np9eYIsweJ_RynK7mXlB1vYCN8BCRbgp9MrXPRzGlLiShLBd5HGnRjYsLsb6p02eDpFKuNu_jwKLzlvdRjJR5fQPpCxUFlpPL_55HXWZtwfWeyolAuxK7q2V2Nc6p1J-cu",
+          "key-data": {
+            "account-id": "2728142649001",
+            "apis": [
+              "search"
+            ],
+            "allowed-domains": [
+              "https://54.210.55.162"
+            ]
+          }
+        }
+    KeyData:
+      title: key-data
+      required:
+        - account-id
+        - apis
+        - allowed-domains
+        - require-ad-config
+        - geo
+      type: object
+      properties:
+        account-id:
+          type: string
+          description: The Video Cloud account id
+        apis:
+          type: array
+          items:
+            type: string
+          description: Array of apis permitted for the key
+        allowed-domains:
+          type: array
+          items:
+            type: string
+          description: Array of domains allowed to use this key
+        require-ad-config:
+          type: boolean
+          description: >-
+            Whether Playback API requests require an ad-config-id URL parameter
+            for server-side ad insertion
+        geo:
+          description: Map of geo-filtering properties
+          $ref: '#/components/schemas/KeyData.geo'
+    KeyData.geo:
+      title: key-data.geo
+      required:
+        - countries
+        - exclude_countries
+      type: object
+      properties:
+        countries:
+          type: array
+          items:
+            type: string
+          description: >-
+            Array of ISO 3166 list of 2- or 4-letter codes in lower-case (search
+            for &quot;country codes&quot;)
+        exclude_countries:
+          type: boolean
+          description: >-
+            If true, country array is treated as a list of countries excluded
+            from viewing. If false, the country array is a list of countries
+            included for viewing.
+    GetPolicy200:
+      title: Get_Policy200
+      required:
+        - key_string
+        - key-data
+      type: object
+      properties:
+        key_string:
+          type: string
+          description: The policy key string
+        key-data:
+          description: Map of key data prescribing the policy
+          $ref: '#/components/schemas/KeyData'
+  securitySchemes:
+    BC_OAuth2:
+      type: oauth2
+      description: >-
+        Brightcove OAuth API. See the [support documentation](/oauth/index.html) or [Getting Access Tokens](/oauth/code-samples/oauth-api-sample-get-access-token.html) to learn more
+      flows:
+        clientCredentials:
+          tokenUrl: 'https://oauth.brightcove.com/v4/access_token'
+          scopes:
+            video-cloud/player/read: Read player data
+            video-cloud/player/all: Read/write player data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brightcove_async"
-version = "0.9.0"
+version = "0.10.0"
 description = "An asynchronous client for the Brightcove API."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/brightcove_async/client.py
+++ b/src/brightcove_async/client.py
@@ -12,6 +12,7 @@ from brightcove_async.services.dynamic_ingest import DynamicIngest
 from brightcove_async.services.images import Images
 from brightcove_async.services.ingest_profiles import IngestProfiles
 from brightcove_async.services.live import Live
+from brightcove_async.services.policy import Policy
 from brightcove_async.services.syndication import Syndication
 
 T = TypeVar("T", bound=Base)
@@ -113,6 +114,11 @@ class BrightcoveClient:
     def live(self) -> Live:
         """Access the Live (NextGen Live) API service."""
         return self._get_service("live", Live)
+
+    @property
+    def policy(self) -> Policy:
+        """Access the Policy API service."""
+        return self._get_service("policy", Policy)
 
     async def __aenter__(self) -> Self:
         if self._external_session is not None:

--- a/src/brightcove_async/registry.py
+++ b/src/brightcove_async/registry.py
@@ -8,6 +8,7 @@ from brightcove_async.services.dynamic_ingest import DynamicIngest
 from brightcove_async.services.images import Images
 from brightcove_async.services.ingest_profiles import IngestProfiles
 from brightcove_async.services.live import Live
+from brightcove_async.services.policy import Policy
 from brightcove_async.services.syndication import Syndication
 from brightcove_async.settings import BrightcoveBaseAPIConfig
 
@@ -51,5 +52,9 @@ def build_service_registry(config: BrightcoveBaseAPIConfig) -> dict[str, Service
         "live": ServiceConfig(
             cls=Live,
             base_url=config.live_base_url,
+        ),
+        "policy": ServiceConfig(
+            cls=Policy,
+            base_url=config.policy_base_url,
         ),
     }

--- a/src/brightcove_async/schemas/__init__.py
+++ b/src/brightcove_async/schemas/__init__.py
@@ -202,6 +202,14 @@ from .params import (
     LiveSchedulerListParams,
 )
 
+# ── Policy models ──────────────────────────────────────────────────────────────
+from .policy_model import (
+    CreatePolicyKeyBody,
+    PolicyGeo,
+    PolicyKey,
+    PolicyKeyData,
+)
+
 # ── Syndication models ─────────────────────────────────────────────────────────
 from .syndication_model import (
     Syndication,
@@ -403,4 +411,9 @@ __all__ = [
     "ListAdConfigsResponse",
     "DeleteAdConfigResponse",
     "HealthCheck",
+    # Policy
+    "CreatePolicyKeyBody",
+    "PolicyGeo",
+    "PolicyKey",
+    "PolicyKeyData",
 ]

--- a/src/brightcove_async/schemas/policy_model.py
+++ b/src/brightcove_async/schemas/policy_model.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+
+
+class PolicyGeo(BaseModel):
+    """Geo-filtering properties for a policy key."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    countries: list[str] | None = Field(
+        default=None,
+        description="Array of ISO 3166 2- or 4-letter country codes in lower-case.",
+    )
+    exclude_countries: bool | None = Field(
+        default=None,
+        description="If true, the countries array is treated as a list of countries "
+        "excluded from viewing. If false, it is a list of countries included for "
+        "viewing.",
+    )
+
+
+class PolicyKeyData(BaseModel):
+    """The data prescribing a policy key.
+
+    Used both as the request body payload when creating a policy key and as the
+    ``key-data`` map returned for created/retrieved keys. Only ``account_id`` is
+    required when creating a key; the remaining fields are optional.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    account_id: str = Field(
+        validation_alias="account-id",
+        serialization_alias="account-id",
+        description="The Video Cloud account id.",
+    )
+    apis: list[str] | None = Field(
+        default=None,
+        description='Array of APIs permitted for this key (currently "search" is the '
+        "only available value - it must be included to use the search functionality "
+        "for the Playback API).",
+    )
+    allowed_domains: list[str] | None = Field(
+        default=None,
+        validation_alias="allowed-domains",
+        serialization_alias="allowed-domains",
+        description="For domain restriction, the domains this key will work on.",
+    )
+    require_ad_config: bool | None = Field(
+        default=None,
+        validation_alias="require-ad-config",
+        serialization_alias="require-ad-config",
+        description="Whether Playback API requests require an ad-config-id URL "
+        "parameter for server-side ad insertion.",
+    )
+    geo: PolicyGeo | None = Field(
+        default=None,
+        description="Map of geo-filtering properties.",
+    )
+
+
+class CreatePolicyKeyBody(BaseModel):
+    """Request body for creating a policy key."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    key_data: PolicyKeyData = Field(
+        validation_alias="key-data",
+        serialization_alias="key-data",
+        description="Data for the policy key.",
+    )
+
+
+class PolicyKey(BaseModel):
+    """A policy key and its associated key data.
+
+    Returned both when creating a policy key and when retrieving one. The
+    ``key_string`` field accepts either ``key-string`` or ``key_string`` from the
+    API response.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    key_string: str = Field(
+        validation_alias=AliasChoices("key-string", "key_string"),
+        serialization_alias="key-string",
+        description="The policy key string.",
+    )
+    key_data: PolicyKeyData = Field(
+        validation_alias="key-data",
+        serialization_alias="key-data",
+        description="Map of key data prescribing the policy.",
+    )

--- a/src/brightcove_async/services/base.py
+++ b/src/brightcove_async/services/base.py
@@ -247,6 +247,7 @@ class Base(ABC):
         body = (
             payload.model_dump(
                 mode="json",
+                by_alias=True,
                 exclude_none=True,
                 exclude_unset=True,
                 exclude_defaults=True,

--- a/src/brightcove_async/services/policy.py
+++ b/src/brightcove_async/services/policy.py
@@ -34,6 +34,9 @@ class Policy(Base):
     ) -> PolicyKey:
         """Create a new policy key to access the Playback API.
 
+        The account id in ``key_data`` must match the ``account_id`` path
+        argument; a ``ValueError`` is raised if they differ.
+
         Args:
             account_id: Video Cloud account ID.
             key_data: The data prescribing the policy key (account id, permitted
@@ -42,6 +45,12 @@ class Policy(Base):
         Returns:
             The created policy key, including its key string.
         """
+        if key_data.account_id != account_id:
+            raise ValueError(
+                "key_data.account_id "
+                f"({key_data.account_id!r}) must match the account_id path "
+                f"argument ({account_id!r})."
+            )
         return await self.fetch_data(
             endpoint=f"{self.base_url}/accounts/{account_id}/policy_keys",
             model=PolicyKey,

--- a/src/brightcove_async/services/policy.py
+++ b/src/brightcove_async/services/policy.py
@@ -1,0 +1,69 @@
+import aiohttp
+
+from brightcove_async.protocols import OAuthClientProtocol
+from brightcove_async.schemas.policy_model import (
+    CreatePolicyKeyBody,
+    PolicyKey,
+    PolicyKeyData,
+)
+from brightcove_async.services.base import Base
+
+
+class Policy(Base):
+    """Brightcove Policy API service.
+
+    The Policy API creates and retrieves policy keys used to access the Playback
+    API outside the context of a Brightcove Player. Policy keys are generated
+    automatically for Brightcove Players, so this service is for generating keys
+    for direct Playback API access.
+    """
+
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        oauth: OAuthClientProtocol,
+        base_url: str,
+        limit: int = 10,
+    ) -> None:
+        super().__init__(session=session, oauth=oauth, base_url=base_url, limit=limit)
+
+    async def create_policy_key(
+        self,
+        account_id: str,
+        key_data: PolicyKeyData,
+    ) -> PolicyKey:
+        """Create a new policy key to access the Playback API.
+
+        Args:
+            account_id: Video Cloud account ID.
+            key_data: The data prescribing the policy key (account id, permitted
+                apis, allowed domains, ad-config requirement, geo-filtering).
+
+        Returns:
+            The created policy key, including its key string.
+        """
+        return await self.fetch_data(
+            endpoint=f"{self.base_url}/accounts/{account_id}/policy_keys",
+            model=PolicyKey,
+            method="POST",
+            payload=CreatePolicyKeyBody(key_data=key_data),
+        )
+
+    async def get_policy_key(
+        self,
+        account_id: str,
+        key_string: str,
+    ) -> PolicyKey:
+        """Get a policy key associated with a policy key string.
+
+        Args:
+            account_id: Video Cloud account ID.
+            key_string: The key string for the policy.
+
+        Returns:
+            The policy key and its associated key data.
+        """
+        return await self.fetch_data(
+            endpoint=f"{self.base_url}/accounts/{account_id}/policy_keys/{key_string}",
+            model=PolicyKey,
+        )

--- a/src/brightcove_async/settings.py
+++ b/src/brightcove_async/settings.py
@@ -20,3 +20,4 @@ class BrightcoveBaseAPIConfig(BaseSettings):
     audience_base_url: str = "https://audience.api.brightcove.com/v1"
     images_base_url: str = "https://images.brightcovecdn.com"
     live_base_url: str = "https://api.live.brightcove.com"
+    policy_base_url: str = "https://policy.api.brightcove.com/v1"

--- a/tests/test_base_service.py
+++ b/tests/test_base_service.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 
 from brightcove_async.exceptions import (
     BrightcoveAuthError,
@@ -18,6 +18,19 @@ class DummyModel(BaseModel):
 
     id: int
     name: str
+
+
+class AliasedModel(BaseModel):
+    """Test model with hyphenated serialization aliases for fetch_data tests."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    account_id: str = Field(
+        validation_alias="account-id", serialization_alias="account-id"
+    )
+    allowed_domains: list[str] = Field(
+        validation_alias="allowed-domains", serialization_alias="allowed-domains"
+    )
 
 
 class DummyOAuth:
@@ -241,6 +254,38 @@ async def test_fetch_data_post_with_json(base_service, mock_session):
 
     call_kwargs = mock_session.request.call_args.kwargs
     assert call_kwargs["json"] == {"id": 2, "name": "Created"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_post_serializes_body_with_aliases(base_service, mock_session):
+    """POST bodies are serialized using field aliases (by_alias=True)."""
+    mock_response = AsyncMock()
+    mock_response.json = AsyncMock(
+        return_value={
+            "account-id": "acct123",
+            "allowed-domains": ["https://example.com"],
+        }
+    )
+    mock_response.raise_for_status = MagicMock()
+
+    mock_session.request.return_value.__aenter__.return_value = mock_response
+
+    request_body = AliasedModel(
+        account_id="acct123", allowed_domains=["https://example.com"]
+    )
+
+    await base_service.fetch_data(
+        endpoint="https://api.example.com/v1/items",
+        model=AliasedModel,
+        method="POST",
+        payload=request_body,
+    )
+
+    call_kwargs = mock_session.request.call_args.kwargs
+    assert call_kwargs["json"] == {
+        "account-id": "acct123",
+        "allowed-domains": ["https://example.com"],
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -401,3 +401,54 @@ async def test_accessing_live_without_context_manager_raises():
     )
     with pytest.raises(RuntimeError, match="Client session not initialized"):
         _ = client.live
+
+
+@pytest.mark.asyncio
+async def test_policy_property_lazy_loads_and_is_singleton():
+    """The policy property returns a cached Policy instance."""
+    from brightcove_async.registry import ServiceConfig
+    from brightcove_async.services.policy import Policy
+
+    services_registry = {
+        "policy": ServiceConfig(
+            cls=Policy, base_url="https://policy.api.brightcove.com/v1"
+        ),
+    }
+
+    with patch("aiohttp.ClientSession") as MockSession:
+        mock_session = AsyncMock()
+        MockSession.return_value = mock_session
+
+        client = BrightcoveClient(
+            services_registry=services_registry,
+            client_id="id",
+            client_secret="secret",
+            oauth_cls=DummyOAuth,
+        )
+
+        async with client as c:
+            policy1 = c.policy
+            policy2 = c.policy
+            assert isinstance(policy1, Policy)
+            assert policy1 is policy2
+
+
+@pytest.mark.asyncio
+async def test_accessing_policy_without_context_manager_raises():
+    from brightcove_async.registry import ServiceConfig
+    from brightcove_async.services.policy import Policy
+
+    services_registry = {
+        "policy": ServiceConfig(
+            cls=Policy, base_url="https://policy.api.brightcove.com/v1"
+        ),
+    }
+
+    client = BrightcoveClient(
+        services_registry=services_registry,
+        client_id="id",
+        client_secret="secret",
+        oauth_cls=DummyOAuth,
+    )
+    with pytest.raises(RuntimeError, match="Client session not initialized"):
+        _ = client.policy

--- a/tests/test_policy_service.py
+++ b/tests/test_policy_service.py
@@ -76,6 +76,19 @@ async def test_create_policy_key(policy_service):
 
 
 @pytest.mark.asyncio
+async def test_create_policy_key_rejects_account_id_mismatch(policy_service):
+    with patch.object(
+        policy_service, "fetch_data", new_callable=AsyncMock
+    ) as mock_fetch:
+        key_data = PolicyKeyData(account_id="other")
+
+        with pytest.raises(ValueError, match="must match the account_id"):
+            await policy_service.create_policy_key("account123", key_data)
+
+        mock_fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_policy_key(policy_service):
     with patch.object(
         policy_service, "fetch_data", new_callable=AsyncMock

--- a/tests/test_policy_service.py
+++ b/tests/test_policy_service.py
@@ -1,0 +1,151 @@
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+
+from brightcove_async.schemas.policy_model import (
+    CreatePolicyKeyBody,
+    PolicyGeo,
+    PolicyKey,
+    PolicyKeyData,
+)
+from brightcove_async.services.policy import Policy
+
+BASE_URL = "https://policy.api.brightcove.com/v1"
+
+
+class DummyOAuth:
+    async def get_access_token(self):
+        return "test_token"
+
+    @property
+    async def headers(self):
+        return {"Authorization": "Bearer test_token"}
+
+
+@pytest.fixture
+def mock_session():
+    return AsyncMock(spec=aiohttp.ClientSession)
+
+
+@pytest.fixture
+def dummy_oauth():
+    return DummyOAuth()
+
+
+@pytest.fixture
+def policy_service(mock_session, dummy_oauth):
+    return Policy(
+        session=mock_session,
+        oauth=dummy_oauth,
+        base_url=BASE_URL,
+        limit=10,
+    )
+
+
+def test_policy_initialization(policy_service):
+    assert policy_service._limit == 10
+    assert policy_service.base_url == BASE_URL
+
+
+@pytest.mark.asyncio
+async def test_create_policy_key(policy_service):
+    with patch.object(
+        policy_service, "fetch_data", new_callable=AsyncMock
+    ) as mock_fetch:
+        mock_fetch.return_value = PolicyKey(
+            key_string="BCpkADawqM1",
+            key_data=PolicyKeyData(account_id="account123"),
+        )
+
+        key_data = PolicyKeyData(
+            account_id="account123",
+            apis=["search"],
+            allowed_domains=["https://example.com"],
+        )
+        await policy_service.create_policy_key("account123", key_data)
+
+        mock_fetch.assert_called_once()
+        call_args = mock_fetch.call_args
+        assert call_args.kwargs["method"] == "POST"
+        assert call_args.kwargs["model"] == PolicyKey
+        assert "account123/policy_keys" in call_args.kwargs["endpoint"]
+        payload = call_args.kwargs["payload"]
+        assert isinstance(payload, CreatePolicyKeyBody)
+        assert payload.key_data is key_data
+
+
+@pytest.mark.asyncio
+async def test_get_policy_key(policy_service):
+    with patch.object(
+        policy_service, "fetch_data", new_callable=AsyncMock
+    ) as mock_fetch:
+        mock_fetch.return_value = PolicyKey(
+            key_string="BCpkADawqM1",
+            key_data=PolicyKeyData(account_id="account123"),
+        )
+
+        await policy_service.get_policy_key("account123", "BCpkADawqM1")
+
+        mock_fetch.assert_called_once()
+        call_args = mock_fetch.call_args
+        assert call_args.kwargs["model"] == PolicyKey
+        assert "account123/policy_keys/BCpkADawqM1" in call_args.kwargs["endpoint"]
+
+
+def test_create_policy_key_body_serializes_with_hyphenated_aliases():
+    """The request body must use the hyphenated keys the API expects."""
+    body = CreatePolicyKeyBody(
+        key_data=PolicyKeyData(
+            account_id="account123",
+            apis=["search"],
+            allowed_domains=["https://example.com"],
+            require_ad_config=True,
+            geo=PolicyGeo(countries=["us"], exclude_countries=False),
+        )
+    )
+
+    dumped = body.model_dump(
+        mode="json", by_alias=True, exclude_none=True, exclude_unset=True
+    )
+
+    assert dumped == {
+        "key-data": {
+            "account-id": "account123",
+            "apis": ["search"],
+            "allowed-domains": ["https://example.com"],
+            "require-ad-config": True,
+            "geo": {"countries": ["us"], "exclude_countries": False},
+        }
+    }
+
+
+def test_policy_key_parses_hyphenated_response():
+    """The response model accepts the hyphenated keys returned by the API."""
+    payload = {
+        "key-string": "BCpkADawqM1",
+        "key-data": {
+            "account-id": "2728142649001",
+            "apis": ["search"],
+            "allowed-domains": ["https://54.210.55.162"],
+        },
+    }
+
+    key = PolicyKey.model_validate(payload)
+
+    assert key.key_string == "BCpkADawqM1"
+    assert key.key_data.account_id == "2728142649001"
+    assert key.key_data.apis == ["search"]
+    assert key.key_data.allowed_domains == ["https://54.210.55.162"]
+
+
+def test_policy_key_parses_underscore_key_string():
+    """The response model also accepts the schema's ``key_string`` spelling."""
+    payload = {
+        "key_string": "BCpkADawqM1",
+        "key-data": {"account-id": "2728142649001"},
+    }
+
+    key = PolicyKey.model_validate(payload)
+
+    assert key.key_string == "BCpkADawqM1"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,6 +4,7 @@ from brightcove_async.services.cms import CMS
 from brightcove_async.services.dynamic_ingest import DynamicIngest
 from brightcove_async.services.images import Images
 from brightcove_async.services.live import Live
+from brightcove_async.services.policy import Policy
 from brightcove_async.services.syndication import Syndication
 from brightcove_async.settings import BrightcoveBaseAPIConfig
 
@@ -115,6 +116,18 @@ def test_build_service_registry_live_config():
     assert live_config.requests_per_second == 10
 
 
+def test_build_service_registry_policy_config():
+    """Test Policy service configuration in registry."""
+    config = BrightcoveBaseAPIConfig()
+    registry = build_service_registry(config)
+
+    policy_config = registry["policy"]
+
+    assert policy_config.cls == Policy
+    assert policy_config.base_url == config.policy_base_url
+    assert policy_config.requests_per_second == 10
+
+
 def test_build_service_registry_custom_urls():
     """Test build_service_registry with custom URLs."""
     config = BrightcoveBaseAPIConfig(
@@ -151,4 +164,5 @@ def test_service_registry_returns_dict():
         "audience",
         "images",
         "live",
+        "policy",
     }

--- a/uv.lock
+++ b/uv.lock
@@ -173,7 +173,7 @@ wheels = [
 
 [[package]]
 name = "brightcove-async"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Implements the Brightcove **Policy API**, used to create and retrieve policy keys for accessing the Playback API outside the context of a Brightcove Player.

Two endpoints from `policy.yaml`:

| Method | Endpoint | Service method |
| --- | --- | --- |
| `POST` | `/accounts/{account_id}/policy_keys` | `client.policy.create_policy_key(account_id, key_data)` |
| `GET` | `/accounts/{account_id}/policy_keys/{key_string}` | `client.policy.get_policy_key(account_id, key_string)` |

## Changes

- **New `Policy` service** (`services/policy.py`) inheriting `Base`, exposed lazily as `client.policy`.
- **New schemas** (`schemas/policy_model.py`): `CreatePolicyKeyBody`, `PolicyKeyData`, `PolicyGeo`, `PolicyKey`, with public re-exports in `schemas/__init__.py`.
  - The Policy API uses hyphenated JSON keys (`key-data`, `account-id`, `allowed-domains`, `require-ad-config`). These are handled with `validation_alias`/`serialization_alias` so the Python field names stay snake_case (and type-check cleanly).
  - `PolicyKey.key_string` accepts both `key-string` (as returned by the API / shown in the spec example) and `key_string` (the schema property name).
- **`Base.fetch_data`** now serializes request bodies with `by_alias=True` so aliased fields are sent with the keys the API expects. This is backward-compatible (fields without aliases are unaffected) and also corrects the existing `capture-images` field in Dynamic Ingest.
- **Wiring**: `registry.py` (`policy` service), `settings.py` (`policy_base_url = https://policy.api.brightcove.com/v1`), `client.py` (`policy` property).
- **Spec**: added `brightcove_open_api_specs/policy.yaml`.
- **Docs/version**: README updated; version bumped to `0.10.0`.

## Tests

- `tests/test_policy_service.py`: service methods (mocked `fetch_data`), request-body hyphenated-alias serialization, and response parsing for both `key-string`/`key_string` spellings.
- Extended `test_registry.py` and `test_client.py` for the new service.

All quality gates pass locally: `ruff check`, `ruff format --check`, `ty check`, and `pytest` (359 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)