### PR TITLE
fix: correct 4xx error classification, timeout mapping, and BasicAuth deprecation

### DIFF
--- a/src/brightcove_async/exceptions.py
+++ b/src/brightcove_async/exceptions.py
@@ -103,7 +103,11 @@ class BrightcoveUnknownError(BrightcoveServerError):
 
 
 def map_status_code_to_exception(status_code: int) -> type[BrightcoveError]:
-    """Map HTTP status codes to Brightcove exception classes using HTTPStatus."""
+    """Map HTTP status codes to Brightcove exception classes.
+
+    Statuses without a dedicated exception fall back by range so callers can
+    still distinguish client errors (4xx) from server errors (5xx).
+    """
     mapping = {
         HTTPStatus.UNAUTHORIZED: BrightcoveAuthError,
         HTTPStatus.FORBIDDEN: BrightcoveForbiddenError,
@@ -115,13 +119,11 @@ def map_status_code_to_exception(status_code: int) -> type[BrightcoveError]:
         HTTPStatus.INTERNAL_SERVER_ERROR: BrightcoveUnknownError,
     }
 
-    try:
-        status = (
-            status_code
-            if isinstance(status_code, HTTPStatus)
-            else HTTPStatus(status_code)
-        )
-    except ValueError:
-        return BrightcoveUnknownError
-
-    return mapping.get(status, BrightcoveUnknownError)
+    exc_class = mapping.get(status_code)  # HTTPStatus keys compare equal to ints
+    if exc_class is not None:
+        return exc_class
+    if 400 <= status_code < 500:
+        return BrightcoveClientError
+    if 500 <= status_code < 600:
+        return BrightcoveServerError
+    return BrightcoveUnknownError

--- a/src/brightcove_async/oauth/oauth.py
+++ b/src/brightcove_async/oauth/oauth.py
@@ -2,7 +2,6 @@ import asyncio
 import time
 
 import aiohttp
-from aiohttp import BasicAuth
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -37,7 +36,12 @@ class OAuthClient:
         reraise=True,
     )
     async def _get_access_token(self) -> None:
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Authorization": aiohttp.encode_basic_auth(
+                self.client_id, self.client_secret
+            ),
+        }
         data = {"grant_type": "client_credentials"}
 
         async with (
@@ -45,7 +49,6 @@ class OAuthClient:
                 url=self.base_url,
                 headers=headers,
                 data=data,
-                auth=BasicAuth(self.client_id, self.client_secret),
                 timeout=aiohttp.ClientTimeout(total=10),
             ) as response,
         ):

--- a/src/brightcove_async/services/base.py
+++ b/src/brightcove_async/services/base.py
@@ -233,9 +233,12 @@ class Base(ABC):
             if uses_oauth:
                 self._oauth.invalidate_token()
             raise
-        except aiohttp.ClientConnectionError as e:
+        except (aiohttp.ClientConnectionError, TimeoutError) as e:
+            # TimeoutError covers aiohttp's total-timeout expiry
+            # (asyncio.TimeoutError), which does not subclass
+            # ClientConnectionError but is equally a transport failure.
             raise BrightcoveConnectionError(
-                message=str(e), endpoint=safe_endpoint
+                message=str(e) or "Request timed out", endpoint=safe_endpoint
             ) from e
 
     @brightcove_retry

--- a/src/brightcove_async/services/base.py
+++ b/src/brightcove_async/services/base.py
@@ -237,8 +237,15 @@ class Base(ABC):
             # TimeoutError covers aiohttp's total-timeout expiry
             # (asyncio.TimeoutError), which does not subclass
             # ClientConnectionError but is equally a transport failure.
+            message = str(e)
+            if not message:
+                message = (
+                    "Request timed out"
+                    if isinstance(e, TimeoutError)
+                    else "Connection error"
+                )
             raise BrightcoveConnectionError(
-                message=str(e) or "Request timed out", endpoint=safe_endpoint
+                message=message, endpoint=safe_endpoint
             ) from e
 
     @brightcove_retry

--- a/tests/test_base_service.py
+++ b/tests/test_base_service.py
@@ -537,6 +537,26 @@ async def test_fetch_data_translates_timeout_error(base_service, mock_session):
 
 
 @pytest.mark.asyncio
+async def test_fetch_data_bare_connection_error_message(base_service, mock_session):
+    """A message-less ClientConnectionError must not be reported as a timeout."""
+    mock_session.request.return_value.__aenter__.side_effect = (
+        aiohttp.ClientConnectionError()
+    )
+
+    from tenacity import RetryError
+
+    with pytest.raises(RetryError) as exc_info:
+        await base_service.fetch_data(
+            endpoint="https://api.example.com/v1/items",
+            model=DummyModel,
+        )
+
+    exc = exc_info.value.last_attempt.exception()
+    assert isinstance(exc, BrightcoveConnectionError)
+    assert exc.message == "Connection error"
+
+
+@pytest.mark.asyncio
 async def test_fetch_data_retries_on_connection_error(base_service, mock_session):
     """Test that connection errors trigger retry mechanism."""
     mock_response = AsyncMock()

--- a/tests/test_base_service.py
+++ b/tests/test_base_service.py
@@ -519,6 +519,24 @@ async def test_fetch_data_translates_connection_error(base_service, mock_session
 
 
 @pytest.mark.asyncio
+async def test_fetch_data_translates_timeout_error(base_service, mock_session):
+    """Test that a request timeout is translated to BrightcoveConnectionError."""
+    mock_session.request.return_value.__aenter__.side_effect = TimeoutError()
+
+    from tenacity import RetryError
+
+    with pytest.raises(RetryError) as exc_info:
+        await base_service.fetch_data(
+            endpoint="https://api.example.com/v1/items",
+            model=DummyModel,
+        )
+
+    exc = exc_info.value.last_attempt.exception()
+    assert isinstance(exc, BrightcoveConnectionError)
+    assert exc.message == "Request timed out"
+
+
+@pytest.mark.asyncio
 async def test_fetch_data_retries_on_connection_error(base_service, mock_session):
     """Test that connection errors trigger retry mechanism."""
     mock_response = AsyncMock()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -101,16 +101,23 @@ def test_map_status_code_internal_server_error():
     assert exc_class == BrightcoveUnknownError
 
 
-def test_map_status_code_unknown():
-    """Test mapping unknown status code defaults to BrightcoveUnknownError."""
+def test_map_status_code_unmapped_falls_back_by_range():
+    """Statuses without a dedicated exception fall back by 4xx/5xx range."""
     exc_class = map_status_code_to_exception(418)  # I'm a teapot
-    assert exc_class == BrightcoveUnknownError
+    assert exc_class == BrightcoveClientError
+
+    exc_class = map_status_code_to_exception(422)  # Unprocessable Entity
+    assert exc_class == BrightcoveClientError
 
     exc_class = map_status_code_to_exception(502)  # Bad Gateway
-    assert exc_class == BrightcoveUnknownError
+    assert exc_class == BrightcoveServerError
 
-    # Note: 999 is not a valid HTTPStatus, so we skip testing it
-    # The function expects valid HTTP status codes
+    exc_class = map_status_code_to_exception(503)  # Service Unavailable
+    assert exc_class == BrightcoveServerError
+
+    # Outside any known range
+    exc_class = map_status_code_to_exception(999)
+    assert exc_class == BrightcoveUnknownError
 
 
 def test_exceptions_can_be_raised():

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -3,7 +3,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
-from aiohttp import BasicAuth
 
 from brightcove_async.oauth.oauth import OAuthClient
 
@@ -52,7 +51,8 @@ async def test_get_access_token_first_request(oauth_client, mock_session):
     mock_session.post.assert_called_once()
     call_kwargs = mock_session.post.call_args.kwargs
     assert call_kwargs["url"] == "https://oauth.brightcove.com/v4/access_token"
-    assert isinstance(call_kwargs["auth"], BasicAuth)
+    expected_auth = aiohttp.encode_basic_auth("test_client_id", "test_secret")
+    assert call_kwargs["headers"]["Authorization"] == expected_auth
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

Three fixes from a codebase review, each with test coverage:

1. **Range-based fallback in `map_status_code_to_exception`** (`exceptions.py`)
   Statuses without a dedicated exception previously fell back to `BrightcoveUnknownError`, which subclasses `BrightcoveServerError`. A 402, 410, 418, or 422 response (the CMS API returns 422 for validation failures) was therefore raised as a *server* error, and callers catching `BrightcoveClientError` silently missed it. Unmapped statuses now fall back by range: 4xx → `BrightcoveClientError`, 5xx → `BrightcoveServerError`, anything else → `BrightcoveUnknownError`. This also drops the `HTTPStatus(status_code)` conversion, so non-standard codes (e.g. 999) no longer take an exception path.

2. **Request timeouts mapped to `BrightcoveConnectionError`** (`services/base.py`)
   `_send_request` mapped `aiohttp.ClientConnectionError` but not `asyncio.TimeoutError`, which aiohttp raises when the total timeout expires and which does not subclass `ClientConnectionError`. A slow endpoint leaked a raw `TimeoutError` to callers and bypassed the tenacity retry (which only retries Brightcove exceptions). Timeouts are now mapped like other transport failures, so they surface consistently and get retried.

3. **Replace deprecated `aiohttp.BasicAuth` in the OAuth client** (`oauth/oauth.py`)
   `BasicAuth` is deprecated in aiohttp 3.14 and will be removed in 4.0; it emitted 8 `DeprecationWarning`s across the test suite. The token fetch now sends the `Authorization` header via `aiohttp.encode_basic_auth()`, as aiohttp recommends. The wire format is identical.

## Reviewer notes

- Item 1 is a deliberate behavior change to the public exception surface: code that specifically expected `BrightcoveUnknownError` for unmapped 4xx/5xx statuses (e.g. 502) will now see `BrightcoveClientError`/`BrightcoveServerError` instead. Since `BrightcoveUnknownError` subclasses `BrightcoveServerError`, handlers catching `BrightcoveServerError` for 5xx are unaffected.
- `tests/test_exceptions.py`, `tests/test_oauth.py` updated accordingly; new timeout-translation test added in `tests/test_base_service.py`.
- Full gate run locally: 388 tests pass, `ruff check`, `ruff format`, and `ty check` clean, and the OAuth deprecation warnings are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)